### PR TITLE
Fix session persistence and add audit logging middleware

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -241,6 +241,7 @@ func configureOpenVPN(db *database.Postgres, permRepo portalRepo.PermissionRepos
 		ovCfg, _ := ovRepo.Get(context.Background())
 		ldapCfg, _ := ldapRepo.Get(context.Background())
 		if ovCfg == nil || ldapCfg == nil {
+			openvpnRoutes.Disable()
 			return
 		}
 		xmlrpcClient := xmlrpc.NewClient(xmlrpc.Config{
@@ -258,6 +259,7 @@ func configureOpenVPN(db *database.Postgres, permRepo portalRepo.PermissionRepos
 		})
 		if err := checkConnections(db, ldapClient, xmlrpcClient); err != nil {
 			log.Println("connectivity check failed:", err)
+			openvpnRoutes.Disable()
 			return
 		}
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"time"
 
 	authHandlers "system-portal/internal/domains/auth/handlers"
@@ -66,10 +67,18 @@ func main() {
 
 	// Initialize JWT service
 	var jwtService *jwt.RSAService
-	if cfg.JWT.AccessPrivateKey != "" && cfg.JWT.RefreshPrivateKey != "" {
+	if cfg.JWT.AccessPrivateKeyPath != "" && cfg.JWT.RefreshPrivateKeyPath != "" {
+		accessData, err := os.ReadFile(cfg.JWT.AccessPrivateKeyPath)
+		if err != nil {
+			logger.Log.Fatal("failed to read access key file:", err)
+		}
+		refreshData, err := os.ReadFile(cfg.JWT.RefreshPrivateKeyPath)
+		if err != nil {
+			logger.Log.Fatal("failed to read refresh key file:", err)
+		}
 		jwtService, err = jwt.NewRSAServiceWithKeys(
-			cfg.JWT.AccessPrivateKey,
-			cfg.JWT.RefreshPrivateKey,
+			string(accessData),
+			string(refreshData),
 			cfg.JWT.AccessTokenExpireDuration,
 			cfg.JWT.RefreshTokenExpireDuration,
 		)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -153,7 +153,7 @@ func initializeDomainRoutes(cfg *config.Config, db *database.Postgres, jwtSvc *j
 	authHandler := authHandlers.NewAuthHandler(authUsecase)
 	authRoutes.Initialize(authHandler)
 
-	userUC := portalUsecases.NewUserUsecase(userRepo)
+	userUC := portalUsecases.NewUserUsecase(userRepo, groupRepo)
 	groupUC := portalUsecases.NewGroupUsecase(groupRepo, permRepo)
 	permUC := portalUsecases.NewPermissionUsecase(permRepo)
 	auditUC := portalUsecases.NewAuditUsecase(auditRepo)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -20,7 +20,6 @@ import (
 	openvpnRoutes "system-portal/internal/domains/openvpn/routes"
 	openvpnUsecases "system-portal/internal/domains/openvpn/usecases"
 	portalHandlers "system-portal/internal/domains/portal/handlers"
-	"system-portal/internal/domains/portal/repositories"
 	portalRepo "system-portal/internal/domains/portal/repositories"
 	portalRepoImpl "system-portal/internal/domains/portal/repositories/impl"
 	portalRoutes "system-portal/internal/domains/portal/routes"

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -122,6 +122,9 @@ func main() {
 	// Verify external service connections when configs are present
 	if err := checkConnections(db, ldapClient, xmlrpcClient); err != nil {
 		log.Println("connectivity check failed:", err)
+		// Disable OpenVPN routes if connections fail
+		xmlrpcClient = nil
+		ldapClient = nil
 	}
 
 	// Initialize middleware

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -96,11 +96,6 @@ func main() {
 		log.Println(refreshPEM)
 	}
 
-	// Load service connection configs from database
-	// Repositories for connection configs
-	ovRepo := portalRepoImpl.NewOpenVPNConfigRepositoryPG(db.DB)
-	ldapRepo := portalRepoImpl.NewLDAPConfigRepositoryPG(db.DB)
-
 	// Initialize middleware
 	authMiddleware := middleware.NewAuthMiddleware(jwtService)
 	corsMiddleware := middleware.NewCorsMiddleware(cfg.Security.CORS)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -155,14 +155,16 @@ func initializeDomainRoutes(cfg *config.Config, db *database.Postgres, jwtSvc *j
 
 	userUC := portalUsecases.NewUserUsecase(userRepo)
 	groupUC := portalUsecases.NewGroupUsecase(groupRepo, permRepo)
+	permUC := portalUsecases.NewPermissionUsecase(permRepo)
 	auditUC := portalUsecases.NewAuditUsecase(auditRepo)
 
 	userHandler := portalHandlers.NewUserHandler(userUC)
 	groupHandler := portalHandlers.NewGroupHandler(groupUC)
+	permHandler := portalHandlers.NewPermissionHandler(permUC)
 	auditHandler := portalHandlers.NewAuditHandler(auditUC)
 	dashboardHandler := portalHandlers.NewDashboardHandler(userRepo, auditRepo)
 
-	portalRoutes.Initialize(userHandler, groupHandler, auditHandler, dashboardHandler)
+	portalRoutes.Initialize(userHandler, groupHandler, permHandler, auditHandler, dashboardHandler)
 
 	// OpenVPN domain initialization
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -90,11 +90,7 @@ func main() {
 		if err != nil {
 			logger.Log.Fatal(err)
 		}
-		accessPEM, _ := jwtService.GetAccessPrivateKeyPEM()
-		refreshPEM, _ := jwtService.GetRefreshPrivateKeyPEM()
 		logger.Log.Warn("generated new RSA keys; store them in config to preserve sessions")
-		logger.Log.Debug("accessPrivateKey:\n" + accessPEM)
-		logger.Log.Debug("refreshPrivateKey:\n" + refreshPEM)
 	}
 
 	// Initialize middleware

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,24 +1,23 @@
 package main
 
 import (
-	"log"
-
 	"system-portal/internal/shared/config"
 	"system-portal/internal/shared/database"
+	"system-portal/pkg/logger"
 )
 
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
-		log.Fatalf("failed to load config: %v", err)
+		logger.Log.Fatalf("failed to load config: %v", err)
 	}
 	pg, err := database.New(cfg.Database)
 	if err != nil {
-		log.Fatalf("database connection error: %v", err)
+		logger.Log.Fatalf("database connection error: %v", err)
 	}
 	defer pg.Close()
 	if err := pg.Migrate(); err != nil {
-		log.Fatalf("migration failed: %v", err)
+		logger.Log.Fatalf("migration failed: %v", err)
 	}
-	log.Println("migrations applied successfully")
+	logger.Log.Info("migrations applied successfully")
 }

--- a/config/config-development.yml
+++ b/config/config-development.yml
@@ -1,20 +1,8 @@
+# Server configuration
 server:
   port: "8080"
   mode: "debug"
   timeout: 30
-
-openvpn:
-  host: "localhost"
-  username: "openvpn"
-  password: "Asim#2023"
-  port: 943
-
-ldap:
-  host: "localhost"
-  port: 389
-  bindDN: "cn=admin,dc=hieuny,dc=com"
-  bindPassword: "Jisai@11?22"
-  baseDN: "ou=Users,dc=hieuny,dc=com"
 
 # PostgreSQL connection
 database:

--- a/config/config-development.yml
+++ b/config/config-development.yml
@@ -48,6 +48,8 @@ redis:
 security:
   # Enable additional security headers
   enableSecurityHeaders: true
+  # Encryption key for sensitive configuration fields (32 bytes)
+  encryptionKey: "0123456789abcdef0123456789abcdef"
   
   # CORS Configuration - CẬP NHẬT QUAN TRỌNG
   cors:

--- a/config/config-development.yml
+++ b/config/config-development.yml
@@ -36,9 +36,10 @@ jwt:
   accessTokenExpireDuration: "1h"
   refreshTokenExpireDuration: "24h"
   
-  # RSA Private Keys (Base64 encoded PEM format)
-  # Leave empty to auto-generate keys on startup
-  # For production, generate your own keys and store securely
+  # RSA Private Keys (PEM format)
+  # If left empty, new keys are generated on every start which invalidates
+  # existing tokens. Populate these with persistent keys to keep sessions alive
+  # across restarts.
   accessPrivateKey: ""
   refreshPrivateKey: ""
   

--- a/config/config-development.yml
+++ b/config/config-development.yml
@@ -24,12 +24,11 @@ jwt:
   accessTokenExpireDuration: "1h"
   refreshTokenExpireDuration: "24h"
   
-  # RSA Private Keys (PEM format)
-  # If left empty, new keys are generated on every start which invalidates
-  # existing tokens. Populate these with persistent keys to keep sessions alive
-  # across restarts.
-  accessPrivateKey: ""
-  refreshPrivateKey: ""
+  # RSA Private Key file paths (PEM format)
+  # Provide paths to PEM files containing the private keys. If left empty,
+  # new keys are generated on every start which invalidates existing tokens.
+  accessPrivateKeyPath: "./config/access_private.pem"
+  refreshPrivateKeyPath: "./config/refresh_private.pem"
   
   # Legacy HMAC Configuration (Deprecated - only for backward compatibility)
   # Only used when useRSA: false

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1895,6 +1895,65 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/portal/groups/{id}/permissions": {
+            "get": {
+                "security": [
+                    {"BearerAuth": []}
+                ],
+                "produces": ["application/json"],
+                "tags": ["Permissions"],
+                "summary": "Get permissions for a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {"type": "array", "items": {"$ref": "#/definitions/entities.Permission"}}
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {"BearerAuth": []}
+                ],
+                "consumes": ["application/json"],
+                "produces": ["application/json"],
+                "tags": ["Permissions"],
+                "summary": "Update group permissions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Permission IDs",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "permission_ids": {"type": "array", "items": {"type": "string"}}
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {"description": "OK", "schema": {"$ref": "#/definitions/response.SuccessResponse"}},
+                    "400": {"description": "Bad Request", "schema": {"$ref": "#/definitions/response.ErrorResponse"}}
+                }
+            }
+        },
         "/api/portal/users": {
             "get": {
                 "security": [

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1946,7 +1946,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.PortalUserRequest"
+                            "$ref": "#/definitions/dto.PortalUserUpdateRequest"
                         }
                     }
                 ],
@@ -2042,7 +2042,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.PortalUserRequest"
+                            "$ref": "#/definitions/dto.PortalUserUpdateRequest"
                         }
                     }
                 ],
@@ -2706,7 +2706,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.PortalUserRequest": {
+                "dto.PortalUserRequest": {
             "type": "object",
             "required": [
                 "email",
@@ -2726,6 +2726,20 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.PortalUserUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "fullName": {
+                    "type": "string"
+                },
+                "groupId": {
+                    "type": "string"
+                },
+                "password": {
                     "type": "string"
                 }
             }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -173,6 +173,38 @@ const docTemplate = `{
         },
         "/api/openvpn/bulk/groups/template": {
             "get": {
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "username"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "group"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "ip"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "resource"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "from"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "to"
+                    }
+                ],
                 "security": [
                     {
                         "BearerAuth": []
@@ -1589,6 +1621,11 @@ const docTemplate = `{
                     {
                         "type": "string",
                         "in": "query",
+                        "name": "resource"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
                         "name": "from"
                     },
                     {
@@ -1634,6 +1671,38 @@ const docTemplate = `{
         },
         "/api/portal/audit/logs/export": {
             "get": {
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "username"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "group"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "ip"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "resource"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "from"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "to"
+                    }
+                ],
                 "security": [
                     {
                         "BearerAuth": []

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1570,6 +1570,43 @@ const docTemplate = `{
         },
         "/api/portal/audit/logs": {
             "get": {
+                "parameters": [
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "username"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "group"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "ip"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "from"
+                    },
+                    {
+                        "type": "string",
+                        "in": "query",
+                        "name": "to"
+                    },
+                    {
+                        "type": "integer",
+                        "in": "query",
+                        "name": "page"
+                    },
+                    {
+                        "type": "integer",
+                        "in": "query",
+                        "name": "limit"
+                    }
+                ],
                 "security": [
                     {
                         "BearerAuth": []
@@ -3940,29 +3977,41 @@ const docTemplate = `{
                 }
             }
         },
-        "entities.AuditLog": {
-            "type": "object",
-            "properties": {
-                "action": {
-                    "type": "string"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "resource": {
-                    "type": "string"
-                },
-                "success": {
-                    "type": "boolean"
-                },
-                "userID": {
-                    "type": "string"
-                }
-            }
-        },
+       "entities.AuditLog": {
+           "type": "object",
+           "properties": {
+               "id": {
+                   "type": "string"
+               },
+               "userID": {
+                   "type": "string"
+               },
+               "username": {
+                   "type": "string"
+               },
+               "userGroup": {
+                   "type": "string"
+               },
+               "action": {
+                   "type": "string"
+               },
+               "resourceType": {
+                   "type": "string"
+               },
+               "resourceName": {
+                   "type": "string"
+               },
+               "ipAddress": {
+                   "type": "string"
+               },
+               "success": {
+                   "type": "boolean"
+               },
+               "createdAt": {
+                   "type": "string"
+               }
+           }
+       },
         "entities.Permission": {
             "type": "object",
             "properties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2088,7 +2088,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.PortalUserRequest"
+                            "$ref": "#/definitions/dto.PortalUserUpdateRequest"
                         }
                     }
                 ],
@@ -2772,6 +2772,20 @@
                     "type": "string"
                 },
                 "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "dto.PortalUserUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "fullName": {
+                    "type": "string"
+                },
+                "groupId": {
+                    "type": "string"
+                },
+                "password": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1563,6 +1563,15 @@
         },
         "/api/portal/audit/logs": {
             "get": {
+                "parameters": [
+                    {"type": "string", "in": "query", "name": "username"},
+                    {"type": "string", "in": "query", "name": "group"},
+                    {"type": "string", "in": "query", "name": "ip"},
+                    {"type": "string", "in": "query", "name": "from"},
+                    {"type": "string", "in": "query", "name": "to"},
+                    {"type": "integer", "in": "query", "name": "page"},
+                    {"type": "integer", "in": "query", "name": "limit"}
+                ],
                 "security": [
                     {
                         "BearerAuth": []
@@ -3936,22 +3945,34 @@
         "entities.AuditLog": {
             "type": "object",
             "properties": {
-                "action": {
-                    "type": "string"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
                 "id": {
                     "type": "string"
                 },
-                "resource": {
+                "userID": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "userGroup": {
+                    "type": "string"
+                },
+                "action": {
+                    "type": "string"
+                },
+                "resourceType": {
+                    "type": "string"
+                },
+                "resourceName": {
+                    "type": "string"
+                },
+                "ipAddress": {
                     "type": "string"
                 },
                 "success": {
                     "type": "boolean"
                 },
-                "userID": {
+                "createdAt": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1567,6 +1567,7 @@
                     {"type": "string", "in": "query", "name": "username"},
                     {"type": "string", "in": "query", "name": "group"},
                     {"type": "string", "in": "query", "name": "ip"},
+                    {"type": "string", "in": "query", "name": "resource"},
                     {"type": "string", "in": "query", "name": "from"},
                     {"type": "string", "in": "query", "name": "to"},
                     {"type": "integer", "in": "query", "name": "page"},
@@ -1599,6 +1600,14 @@
         },
         "/api/portal/audit/logs/export": {
             "get": {
+                "parameters": [
+                    {"type": "string", "in": "query", "name": "username"},
+                    {"type": "string", "in": "query", "name": "group"},
+                    {"type": "string", "in": "query", "name": "ip"},
+                    {"type": "string", "in": "query", "name": "resource"},
+                    {"type": "string", "in": "query", "name": "from"},
+                    {"type": "string", "in": "query", "name": "to"}
+                ],
                 "security": [
                     {
                         "BearerAuth": []
@@ -1623,6 +1632,14 @@
         },
         "/api/portal/audit/stats": {
             "get": {
+                "parameters": [
+                    {"type": "string", "in": "query", "name": "username"},
+                    {"type": "string", "in": "query", "name": "group"},
+                    {"type": "string", "in": "query", "name": "ip"},
+                    {"type": "string", "in": "query", "name": "resource"},
+                    {"type": "string", "in": "query", "name": "from"},
+                    {"type": "string", "in": "query", "name": "to"}
+                ],
                 "security": [
                     {
                         "BearerAuth": []

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1860,6 +1860,68 @@
                 }
             }
         },
+        "/api/portal/groups/{id}/permissions": {
+            "get": {
+                "security": [
+                    {"BearerAuth": []}
+                ],
+                "produces": ["application/json"],
+                "tags": ["Permissions"],
+                "summary": "Get permissions for a group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {"type": "array", "items": {"$ref": "#/definitions/entities.Permission"}}
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {"BearerAuth": []}
+                ],
+                "consumes": ["application/json"],
+                "produces": ["application/json"],
+                "tags": ["Permissions"],
+                "summary": "Update group permissions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Permission IDs",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "permission_ids": {
+                                    "type": "array",
+                                    "items": {"type": "string"}
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {"description": "OK", "schema": {"$ref": "#/definitions/response.SuccessResponse"}},
+                    "400": {"description": "Bad Request", "schema": {"$ref": "#/definitions/response.ErrorResponse"}}
+                }
+            }
+        },
         "/api/portal/permissions": {
             "get": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1860,6 +1860,87 @@
                 }
             }
         },
+        "/api/portal/permissions": {
+            "get": {
+                "security": [
+                    {"BearerAuth": []}
+                ],
+                "produces": ["application/json"],
+                "tags": ["Permissions"],
+                "summary": "List permissions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {"$ref": "#/definitions/entities.Permission"}
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {"BearerAuth": []}
+                ],
+                "consumes": ["application/json"],
+                "produces": ["application/json"],
+                "tags": ["Permissions"],
+                "summary": "Create permission",
+                "parameters": [
+                    {
+                        "description": "Permission data",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {"$ref": "#/definitions/entities.Permission"}
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {"$ref": "#/definitions/response.SuccessResponse"}
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {"$ref": "#/definitions/response.ErrorResponse"}
+                    }
+                }
+            }
+        },
+        "/api/portal/permissions/{id}": {
+            "put": {
+                "security": [
+                    {"BearerAuth": []}
+                ],
+                "consumes": ["application/json"],
+                "produces": ["application/json"],
+                "tags": ["Permissions"],
+                "summary": "Update permission",
+                "parameters": [
+                    {"type": "string", "description": "Permission ID", "name": "id", "in": "path", "required": true},
+                    {"description": "Permission data", "name": "request", "in": "body", "required": true, "schema": {"$ref": "#/definitions/entities.Permission"}}
+                ],
+                "responses": {
+                    "200": {"description": "OK", "schema": {"$ref": "#/definitions/response.SuccessResponse"}},
+                    "400": {"description": "Bad Request", "schema": {"$ref": "#/definitions/response.ErrorResponse"}}
+                }
+            },
+            "delete": {
+                "security": [
+                    {"BearerAuth": []}
+                ],
+                "produces": ["application/json"],
+                "tags": ["Permissions"],
+                "summary": "Delete permission",
+                "parameters": [
+                    {"type": "string", "description": "Permission ID", "name": "id", "in": "path", "required": true}
+                ],
+                "responses": {
+                    "200": {"description": "OK", "schema": {"$ref": "#/definitions/response.SuccessResponse"}},
+                    "400": {"description": "Bad Request", "schema": {"$ref": "#/definitions/response.ErrorResponse"}}
+                }
+            }
+        },
         "/api/portal/users": {
             "get": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2424,6 +2424,64 @@ paths:
       summary: Get portal group
       tags:
       - Portal Groups
+  /api/portal/groups/{id}/permissions:
+    get:
+      parameters:
+      - description: Group ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/entities.Permission'
+      security:
+      - BearerAuth: []
+      summary: Get permissions for a group
+      tags:
+      - Permissions
+    put:
+      consumes:
+      - application/json
+      parameters:
+      - description: Group ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Permission IDs
+        in: body
+        name: request
+        required: true
+        schema:
+          type: object
+          properties:
+            permission_ids:
+              type: array
+              items:
+                type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.SuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/response.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Update group permissions
+      tags:
+      - Permissions
   /api/portal/permissions:
     get:
       produces:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2386,7 +2386,7 @@ paths:
       - BearerAuth: []
       summary: Create portal group
       tags:
-      - Portal Groups
+  - Portal Groups
   /api/portal/groups/{id}:
     get:
       parameters:
@@ -2415,6 +2415,103 @@ paths:
       summary: Get portal group
       tags:
       - Portal Groups
+  /api/portal/permissions:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/entities.Permission'
+            type: array
+      security:
+      - BearerAuth: []
+      summary: List permissions
+      tags:
+      - Permissions
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Permission data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/entities.Permission'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/response.SuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/response.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Create permission
+      tags:
+      - Permissions
+  /api/portal/permissions/{id}:
+    put:
+      consumes:
+      - application/json
+      parameters:
+      - description: Permission ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Permission data
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/entities.Permission'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.SuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/response.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Update permission
+      tags:
+      - Permissions
+    delete:
+      parameters:
+      - description: Permission ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.SuccessResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/response.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete permission
+      tags:
+      - Permissions
   /api/portal/users:
     get:
       description: Retrieve all portal users

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2241,6 +2241,9 @@ paths:
         name: ip
         type: string
       - in: query
+        name: resource
+        type: string
+      - in: query
         name: from
         type: string
       - in: query
@@ -2268,6 +2271,25 @@ paths:
       - Audit
   /api/portal/audit/logs/export:
     get:
+      parameters:
+      - in: query
+        name: username
+        type: string
+      - in: query
+        name: group
+        type: string
+      - in: query
+        name: ip
+        type: string
+      - in: query
+        name: resource
+        type: string
+      - in: query
+        name: from
+        type: string
+      - in: query
+        name: to
+        type: string
       produces:
       - application/json
       responses:
@@ -2282,6 +2304,25 @@ paths:
       - Audit
   /api/portal/audit/stats:
     get:
+      parameters:
+      - in: query
+        name: username
+        type: string
+      - in: query
+        name: group
+        type: string
+      - in: query
+        name: ip
+        type: string
+      - in: query
+        name: resource
+        type: string
+      - in: query
+        name: from
+        type: string
+      - in: query
+        name: to
+        type: string
       produces:
       - application/json
       responses:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1155,17 +1155,25 @@ definitions:
     type: object
   entities.AuditLog:
     properties:
-      action:
-        type: string
-      createdAt:
-        type: string
       id:
         type: string
-      resource:
+      userID:
+        type: string
+      username:
+        type: string
+      userGroup:
+        type: string
+      action:
+        type: string
+      resourceType:
+        type: string
+      resourceName:
+        type: string
+      ipAddress:
         type: string
       success:
         type: boolean
-      userID:
+      createdAt:
         type: string
     type: object
   entities.Permission:
@@ -2213,6 +2221,28 @@ paths:
       - VPN Status
   /api/portal/audit/logs:
     get:
+      parameters:
+      - in: query
+        name: username
+        type: string
+      - in: query
+        name: group
+        type: string
+      - in: query
+        name: ip
+        type: string
+      - in: query
+        name: from
+        type: string
+      - in: query
+        name: to
+        type: string
+      - in: query
+        name: page
+        type: integer
+      - in: query
+        name: limit
+        type: integer
       produces:
       - application/json
       responses:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -265,6 +265,15 @@ definitions:
     - email
     - username
     type: object
+  dto.PortalUserUpdateRequest:
+    properties:
+      fullName:
+        type: string
+      groupId:
+        type: string
+      password:
+        type: string
+    type: object
   dto.PortalUserResponse:
     properties:
       email:
@@ -2624,7 +2633,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.PortalUserRequest'
+          $ref: '#/definitions/dto.PortalUserUpdateRequest'
       produces:
       - application/json
       responses:

--- a/internal/domains/auth/entities/session.go
+++ b/internal/domains/auth/entities/session.go
@@ -15,5 +15,6 @@ type Session struct {
 	ExpiresAt        time.Time
 	RefreshExpiresAt time.Time
 	IsActive         bool
+	IPAddress        string
 	CreatedAt        time.Time
 }

--- a/internal/domains/auth/handlers/auth_handler.go
+++ b/internal/domains/auth/handlers/auth_handler.go
@@ -36,7 +36,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		http.RespondWithBadRequest(c, "invalid request")
 		return
 	}
-	access, refresh, userID, role, err := h.usecase.Login(c.Request.Context(), req.Username, req.Password)
+	access, refresh, userID, role, err := h.usecase.Login(c.Request.Context(), req.Username, req.Password, c.ClientIP())
 	if err != nil {
 		logger.Log.WithError(err).WithField("username", req.Username).Error("login failed")
 		http.RespondWithUnauthorized(c, "login failed")
@@ -46,6 +46,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	c.Set("username", req.Username)
 	c.Set("userID", userID)
 	c.Set("role", role)
+	c.Set("ip", c.ClientIP())
 	http.RespondWithSuccess(c, 200, dto.TokenResponse{AccessToken: access, RefreshToken: refresh})
 }
 

--- a/internal/domains/auth/handlers/auth_handler.go
+++ b/internal/domains/auth/handlers/auth_handler.go
@@ -36,13 +36,16 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		http.RespondWithBadRequest(c, "invalid request")
 		return
 	}
-	access, refresh, err := h.usecase.Login(c.Request.Context(), req.Username, req.Password)
+	access, refresh, userID, role, err := h.usecase.Login(c.Request.Context(), req.Username, req.Password)
 	if err != nil {
 		logger.Log.WithError(err).WithField("username", req.Username).Error("login failed")
 		http.RespondWithUnauthorized(c, "login failed")
 		return
 	}
 	logger.Log.WithField("username", req.Username).Info("user logged in")
+	c.Set("username", req.Username)
+	c.Set("userID", userID)
+	c.Set("role", role)
 	http.RespondWithSuccess(c, 200, dto.TokenResponse{AccessToken: access, RefreshToken: refresh})
 }
 

--- a/internal/domains/auth/repositories/impl/session_repository_pg.go
+++ b/internal/domains/auth/repositories/impl/session_repository_pg.go
@@ -18,9 +18,9 @@ func NewSessionRepositoryPG(db *sql.DB) repositories.SessionRepository {
 
 func (r *pgSessionRepo) Create(ctx context.Context, s *entities.Session) error {
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO user_sessions (id, user_id, token_hash, refresh_token_hash, expires_at, refresh_expires_at, is_active, created_at)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
-		s.ID, s.UserID, s.TokenHash, s.RefreshTokenHash, s.ExpiresAt, s.RefreshExpiresAt, s.IsActive, s.CreatedAt,
+		`INSERT INTO user_sessions (id, user_id, token_hash, refresh_token_hash, expires_at, refresh_expires_at, is_active, ip_address, created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+		s.ID, s.UserID, s.TokenHash, s.RefreshTokenHash, s.ExpiresAt, s.RefreshExpiresAt, s.IsActive, s.IPAddress, s.CreatedAt,
 	)
 	if err != nil {
 		logger.Log.WithError(err).Error("create session failed")
@@ -30,10 +30,10 @@ func (r *pgSessionRepo) Create(ctx context.Context, s *entities.Session) error {
 
 func (r *pgSessionRepo) GetByTokenHash(ctx context.Context, hash string) (*entities.Session, error) {
 	row := r.db.QueryRowContext(ctx,
-		`SELECT id, user_id, token_hash, refresh_token_hash, expires_at, refresh_expires_at, is_active, created_at
+		`SELECT id, user_id, token_hash, refresh_token_hash, expires_at, refresh_expires_at, is_active, ip_address, created_at
          FROM user_sessions WHERE token_hash=$1`, hash)
 	var s entities.Session
-	err := row.Scan(&s.ID, &s.UserID, &s.TokenHash, &s.RefreshTokenHash, &s.ExpiresAt, &s.RefreshExpiresAt, &s.IsActive, &s.CreatedAt)
+	err := row.Scan(&s.ID, &s.UserID, &s.TokenHash, &s.RefreshTokenHash, &s.ExpiresAt, &s.RefreshExpiresAt, &s.IsActive, &s.IPAddress, &s.CreatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}

--- a/internal/domains/auth/usecases/auth_usecase.go
+++ b/internal/domains/auth/usecases/auth_usecase.go
@@ -8,7 +8,7 @@ import (
 
 // AuthUsecase defines authentication business logic.
 type AuthUsecase interface {
-	Login(ctx context.Context, username, password string) (string, string, uuid.UUID, string, error)
+	Login(ctx context.Context, username, password, ip string) (string, string, uuid.UUID, string, error)
 	Refresh(ctx context.Context, refreshToken string) (string, string, error)
 	Validate(ctx context.Context, token string) error
 	Logout(ctx context.Context, token string) error

--- a/internal/domains/auth/usecases/auth_usecase.go
+++ b/internal/domains/auth/usecases/auth_usecase.go
@@ -1,10 +1,14 @@
 package usecases
 
-import "context"
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
 
 // AuthUsecase defines authentication business logic.
 type AuthUsecase interface {
-	Login(ctx context.Context, username, password string) (string, string, error)
+	Login(ctx context.Context, username, password string) (string, string, uuid.UUID, string, error)
 	Refresh(ctx context.Context, refreshToken string) (string, string, error)
 	Validate(ctx context.Context, token string) error
 	Logout(ctx context.Context, token string) error

--- a/internal/domains/auth/usecases/auth_usecase_impl.go
+++ b/internal/domains/auth/usecases/auth_usecase_impl.go
@@ -57,9 +57,11 @@ func (u *authUsecaseImpl) Login(ctx context.Context, username, password, ip stri
 		}
 	}
 
-	role := "support"
+	role := ""
 	if g, err := u.groups.GetByID(ctx, usr.GroupID); err == nil && g != nil {
 		role = g.Name
+	} else if err != nil {
+		logger.Log.WithError(err).Warn("failed to fetch user group")
 	}
 	access, _ := u.jwt.GenerateAccessToken(username, role)
 	refresh, _ := u.jwt.GenerateRefreshToken(username, role)
@@ -99,9 +101,11 @@ func (u *authUsecaseImpl) Refresh(ctx context.Context, refreshToken string) (str
 		return "", "", errors.New("invalid credentials")
 	}
 
-	role := "support"
+	role := ""
 	if g, err := u.groups.GetByID(ctx, usr.GroupID); err == nil && g != nil {
 		role = g.Name
+	} else if err != nil {
+		logger.Log.WithError(err).Warn("failed to fetch user group")
 	}
 	access, _ := u.jwt.GenerateAccessToken(claims.Username, role)
 	refreshNew, _ := u.jwt.GenerateRefreshToken(claims.Username, role)

--- a/internal/domains/auth/usecases/auth_usecase_impl.go
+++ b/internal/domains/auth/usecases/auth_usecase_impl.go
@@ -25,7 +25,7 @@ func NewAuthUsecase(sessionRepo repositories.SessionRepository, userRepo portalr
 	return &authUsecaseImpl{sessions: sessionRepo, users: userRepo, jwt: jwtSvc}
 }
 
-func (u *authUsecaseImpl) Login(ctx context.Context, username, password string) (string, string, uuid.UUID, string, error) {
+func (u *authUsecaseImpl) Login(ctx context.Context, username, password, ip string) (string, string, uuid.UUID, string, error) {
 	logger.Log.WithField("username", username).Info("login attempt")
 	usr, err := u.users.GetByUsername(ctx, username)
 	if err != nil {
@@ -62,6 +62,7 @@ func (u *authUsecaseImpl) Login(ctx context.Context, username, password string) 
 		RefreshExpiresAt: time.Now().Add(24 * time.Hour),
 		IsActive:         true,
 		CreatedAt:        time.Now(),
+		IPAddress:        ip,
 	}
 	u.sessions.Create(ctx, s)
 	logger.Log.WithField("username", username).Info("session created")

--- a/internal/domains/auth/usecases/auth_usecase_impl.go
+++ b/internal/domains/auth/usecases/auth_usecase_impl.go
@@ -78,8 +78,11 @@ func (u *authUsecaseImpl) Login(ctx context.Context, username, password, ip stri
 		CreatedAt:        time.Now(),
 		IPAddress:        ip,
 	}
-	u.sessions.Create(ctx, s)
-	logger.Log.WithField("username", username).Info("session created")
+	if err := u.sessions.Create(ctx, s); err != nil {
+		logger.Log.WithError(err).Error("failed to create session")
+	} else {
+		logger.Log.WithField("username", username).Info("session created")
+	}
 	return access, refresh, usr.ID, role, nil
 }
 
@@ -121,8 +124,11 @@ func (u *authUsecaseImpl) Refresh(ctx context.Context, refreshToken string) (str
 		IsActive:         true,
 		CreatedAt:        time.Now(),
 	}
-	u.sessions.Create(ctx, s)
-	logger.Log.WithField("username", claims.Username).Info("session refreshed")
+	if err := u.sessions.Create(ctx, s); err != nil {
+		logger.Log.WithError(err).Error("failed to create session on refresh")
+	} else {
+		logger.Log.WithField("username", claims.Username).Info("session refreshed")
+	}
 	return access, refreshNew, nil
 }
 

--- a/internal/domains/openvpn/routes/openvpn_routes.go
+++ b/internal/domains/openvpn/routes/openvpn_routes.go
@@ -16,6 +16,7 @@ var (
 	configHandler     *handlers.ConfigHandler
 	vpnStatusHandler  *handlers.VPNStatusHandler
 	disconnectHandler *handlers.DisconnectHandler
+	permMiddleware    *middleware.PermissionMiddleware
 )
 
 // Initialize sets up the handler dependencies
@@ -26,6 +27,7 @@ func Initialize(
 	cfh *handlers.ConfigHandler,
 	vsh *handlers.VPNStatusHandler,
 	dh *handlers.DisconnectHandler,
+	pmw *middleware.PermissionMiddleware,
 ) {
 	userHandler = uh
 	groupHandler = gh
@@ -33,6 +35,7 @@ func Initialize(
 	configHandler = cfh
 	vpnStatusHandler = vsh
 	disconnectHandler = dh
+	permMiddleware = pmw
 }
 
 // RegisterRoutes registers all OpenVPN routes with permission-based access control
@@ -51,22 +54,22 @@ func registerUserRoutes(openvpn *gin.RouterGroup) {
 	users := openvpn.Group("/users")
 	{
 		// List and view users (both admin and support)
-		users.GET("", middleware.RequirePermission("openvpn.view_users"), userHandler.ListUsers)
-		users.GET("/expirations", middleware.RequirePermission("openvpn.view_users"), userHandler.GetUserExpirations)
-		users.GET("/:username", middleware.RequirePermission("openvpn.view_users"), userHandler.GetUser)
+		users.GET("", permMiddleware.RequirePermission("openvpn.view_users"), userHandler.ListUsers)
+		users.GET("/expirations", permMiddleware.RequirePermission("openvpn.view_users"), userHandler.GetUserExpirations)
+		users.GET("/:username", permMiddleware.RequirePermission("openvpn.view_users"), userHandler.GetUser)
 
 		// Create and edit users (both admin and support)
-		users.POST("", middleware.RequirePermission("openvpn.create_users"), userHandler.CreateUser)
-		users.PUT("/:username", middleware.RequirePermission("openvpn.edit_users"), userHandler.UpdateUser)
+		users.POST("", permMiddleware.RequirePermission("openvpn.create_users"), userHandler.CreateUser)
+		users.PUT("/:username", permMiddleware.RequirePermission("openvpn.edit_users"), userHandler.UpdateUser)
 
 		// User actions (both admin and support can enable/disable)
-		users.PUT("/:username/:action", middleware.RequirePermission("openvpn.edit_users"), userHandler.UserAction)
+		users.PUT("/:username/:action", permMiddleware.RequirePermission("openvpn.edit_users"), userHandler.UserAction)
 
 		// Delete users (admin only)
-		users.DELETE("/:username", middleware.RequirePermission("openvpn.delete_users"), userHandler.DeleteUser)
+		users.DELETE("/:username", permMiddleware.RequirePermission("openvpn.delete_users"), userHandler.DeleteUser)
 
 		// Disconnect users (both admin and support)
-		users.POST("/:username/disconnect", middleware.RequirePermission("openvpn.edit_users"), disconnectHandler.DisconnectUser)
+		users.POST("/:username/disconnect", permMiddleware.RequirePermission("openvpn.edit_users"), disconnectHandler.DisconnectUser)
 	}
 }
 
@@ -74,14 +77,14 @@ func registerGroupRoutes(openvpn *gin.RouterGroup) {
 	groups := openvpn.Group("/groups")
 	{
 		// View groups (both admin and support)
-		groups.GET("", middleware.RequirePermission("openvpn.view_groups"), groupHandler.ListGroups)
-		groups.GET("/:groupName", middleware.RequirePermission("openvpn.view_groups"), groupHandler.GetGroup)
+		groups.GET("", permMiddleware.RequirePermission("openvpn.view_groups"), groupHandler.ListGroups)
+		groups.GET("/:groupName", permMiddleware.RequirePermission("openvpn.view_groups"), groupHandler.GetGroup)
 
 		// Manage groups (admin only)
-		groups.POST("", middleware.RequirePermission("openvpn.manage_groups"), groupHandler.CreateGroup)
-		groups.PUT("/:groupName", middleware.RequirePermission("openvpn.manage_groups"), groupHandler.UpdateGroup)
-		groups.DELETE("/:groupName", middleware.RequirePermission("openvpn.manage_groups"), groupHandler.DeleteGroup)
-		groups.PUT("/:groupName/:action", middleware.RequirePermission("openvpn.manage_groups"), groupHandler.GroupAction)
+		groups.POST("", permMiddleware.RequirePermission("openvpn.manage_groups"), groupHandler.CreateGroup)
+		groups.PUT("/:groupName", permMiddleware.RequirePermission("openvpn.manage_groups"), groupHandler.UpdateGroup)
+		groups.DELETE("/:groupName", permMiddleware.RequirePermission("openvpn.manage_groups"), groupHandler.DeleteGroup)
+		groups.PUT("/:groupName/:action", permMiddleware.RequirePermission("openvpn.manage_groups"), groupHandler.GroupAction)
 	}
 }
 
@@ -92,19 +95,19 @@ func registerBulkRoutes(openvpn *gin.RouterGroup) {
 		userBulk := bulk.Group("/users")
 		{
 			// Create and import (both admin and support)
-			userBulk.POST("/create", middleware.RequirePermission("openvpn.create_users"), bulkHandler.BulkCreateUsers)
-			userBulk.POST("/import", middleware.RequirePermission("openvpn.create_users"), bulkHandler.ImportUsers)
-			userBulk.GET("/template", middleware.RequirePermission("openvpn.view_users"), bulkHandler.ExportUserTemplate)
+			userBulk.POST("/create", permMiddleware.RequirePermission("openvpn.create_users"), bulkHandler.BulkCreateUsers)
+			userBulk.POST("/import", permMiddleware.RequirePermission("openvpn.create_users"), bulkHandler.ImportUsers)
+			userBulk.GET("/template", permMiddleware.RequirePermission("openvpn.view_users"), bulkHandler.ExportUserTemplate)
 
 			// Bulk actions (admin and support, but no delete for support)
-			userBulk.POST("/actions", middleware.RequirePermission("openvpn.edit_users"), bulkHandler.BulkUserActions)
-			userBulk.POST("/extend", middleware.RequirePermission("openvpn.edit_users"), bulkHandler.BulkExtendUsers)
-			userBulk.POST("/disconnect", middleware.RequirePermission("openvpn.edit_users"), disconnectHandler.BulkDisconnectUsers)
+			userBulk.POST("/actions", permMiddleware.RequirePermission("openvpn.edit_users"), bulkHandler.BulkUserActions)
+			userBulk.POST("/extend", permMiddleware.RequirePermission("openvpn.edit_users"), bulkHandler.BulkExtendUsers)
+			userBulk.POST("/disconnect", permMiddleware.RequirePermission("openvpn.edit_users"), disconnectHandler.BulkDisconnectUsers)
 		}
 
 		// Group bulk operations (admin only)
 		groupBulk := bulk.Group("/groups")
-		groupBulk.Use(middleware.RequirePermission("openvpn.manage_groups"))
+		groupBulk.Use(permMiddleware.RequirePermission("openvpn.manage_groups"))
 		{
 			groupBulk.POST("/create", bulkHandler.BulkCreateGroups)
 			groupBulk.POST("/actions", bulkHandler.BulkGroupActions)
@@ -118,8 +121,8 @@ func registerConfigRoutes(openvpn *gin.RouterGroup) {
 	config := openvpn.Group("/config")
 	{
 		// View configuration (both admin and support)
-		config.GET("/server/info", middleware.RequirePermission("openvpn.view_status"), configHandler.GetServerInfo)
-		config.GET("/network", middleware.RequirePermission("openvpn.view_status"), configHandler.GetNetworkConfig)
+		config.GET("/server/info", permMiddleware.RequirePermission("openvpn.view_status"), configHandler.GetServerInfo)
+		config.GET("/network", permMiddleware.RequirePermission("openvpn.view_status"), configHandler.GetNetworkConfig)
 	}
 }
 
@@ -127,6 +130,6 @@ func registerVPNStatusRoutes(openvpn *gin.RouterGroup) {
 	vpn := openvpn.Group("/vpn")
 	{
 		// View VPN status (both admin and support)
-		vpn.GET("/status", middleware.RequirePermission("openvpn.view_status"), vpnStatusHandler.GetVPNStatus)
+		vpn.GET("/status", permMiddleware.RequirePermission("openvpn.view_status"), vpnStatusHandler.GetVPNStatus)
 	}
 }

--- a/internal/domains/openvpn/routes/openvpn_routes.go
+++ b/internal/domains/openvpn/routes/openvpn_routes.go
@@ -18,6 +18,8 @@ var (
 	disconnectHandler *handlers.DisconnectHandler
 	permMiddleware    *middleware.PermissionMiddleware
 	enabled           bool
+	routerGroup       *gin.RouterGroup
+	routesRegistered  bool
 )
 
 // Initialize sets up the handler dependencies
@@ -38,10 +40,23 @@ func Initialize(
 	disconnectHandler = dh
 	permMiddleware = pmw
 	enabled = true
+	if routerGroup != nil && !routesRegistered {
+		RegisterRoutes(routerGroup)
+		routesRegistered = true
+	}
 }
 
 // Enabled reports whether OpenVPN routes are initialized
 func Enabled() bool { return enabled }
+
+// SetRouterGroup stores the router group for dynamic registration
+func SetRouterGroup(rg *gin.RouterGroup) {
+	routerGroup = rg
+	if enabled && !routesRegistered {
+		RegisterRoutes(routerGroup)
+		routesRegistered = true
+	}
+}
 
 // RegisterRoutes registers all OpenVPN routes with permission-based access control
 func RegisterRoutes(router *gin.RouterGroup) {

--- a/internal/domains/openvpn/routes/openvpn_routes.go
+++ b/internal/domains/openvpn/routes/openvpn_routes.go
@@ -17,6 +17,7 @@ var (
 	vpnStatusHandler  *handlers.VPNStatusHandler
 	disconnectHandler *handlers.DisconnectHandler
 	permMiddleware    *middleware.PermissionMiddleware
+	enabled           bool
 )
 
 // Initialize sets up the handler dependencies
@@ -36,7 +37,11 @@ func Initialize(
 	vpnStatusHandler = vsh
 	disconnectHandler = dh
 	permMiddleware = pmw
+	enabled = true
 }
+
+// Enabled reports whether OpenVPN routes are initialized
+func Enabled() bool { return enabled }
 
 // RegisterRoutes registers all OpenVPN routes with permission-based access control
 func RegisterRoutes(router *gin.RouterGroup) {

--- a/internal/domains/portal/dto/audit_dto.go
+++ b/internal/domains/portal/dto/audit_dto.go
@@ -3,9 +3,10 @@ package dto
 import "github.com/google/uuid"
 
 type AuditResponse struct {
-	ID       uuid.UUID `json:"id"`
-	UserID   uuid.UUID `json:"userId"`
-	Action   string    `json:"action"`
-	Resource string    `json:"resource"`
-	Success  bool      `json:"success"`
+	ID           uuid.UUID `json:"id"`
+	UserID       uuid.UUID `json:"userId"`
+	Action       string    `json:"action"`
+	Resource     string    `json:"resource"`
+	ResourceName string    `json:"resourceName"`
+	Success      bool      `json:"success"`
 }

--- a/internal/domains/portal/dto/config_dto.go
+++ b/internal/domains/portal/dto/config_dto.go
@@ -1,0 +1,18 @@
+package dto
+
+// OpenVPNConfigRequest represents payload to set OpenVPN connection details
+type OpenVPNConfigRequest struct {
+	Host     string `json:"host" binding:"required"`
+	Username string `json:"username" binding:"required"`
+	Password string `json:"password" binding:"required"`
+	Port     int    `json:"port" binding:"required"`
+}
+
+// LDAPConfigRequest represents payload to set LDAP connection details
+type LDAPConfigRequest struct {
+	Host         string `json:"host" binding:"required"`
+	Port         int    `json:"port" binding:"required"`
+	BindDN       string `json:"bindDN" binding:"required"`
+	BindPassword string `json:"bindPassword" binding:"required"`
+	BaseDN       string `json:"baseDN" binding:"required"`
+}

--- a/internal/domains/portal/dto/user_dto.go
+++ b/internal/domains/portal/dto/user_dto.go
@@ -10,6 +10,14 @@ type PortalUserRequest struct {
 	GroupID  uuid.UUID `json:"groupId"`
 }
 
+// PortalUserUpdateRequest is used when updating a user. Username and email are
+// intentionally omitted as they cannot be changed.
+type PortalUserUpdateRequest struct {
+	FullName string    `json:"fullName"`
+	Password string    `json:"password"`
+	GroupID  uuid.UUID `json:"groupId"`
+}
+
 type PortalUserResponse struct {
 	ID       uuid.UUID `json:"id"`
 	Username string    `json:"username"`

--- a/internal/domains/portal/entities/audit_filter.go
+++ b/internal/domains/portal/entities/audit_filter.go
@@ -1,0 +1,32 @@
+package entities
+
+import "time"
+
+// AuditFilter defines filtering and pagination for audit logs
+//
+// Limit and Page determine pagination; Offset is calculated from them.
+// Default values are Page=1 and Limit=20 if not provided.
+// FromTime and ToTime can be nil to omit the bound.
+//
+// Username filters by username, UserGroup by group name, IPAddress by IP.
+type AuditFilter struct {
+	Username  string
+	UserGroup string
+	IPAddress string
+	FromTime  *time.Time
+	ToTime    *time.Time
+	Page      int
+	Limit     int
+	Offset    int
+}
+
+// SetDefaults ensures pagination defaults and calculates offset.
+func (f *AuditFilter) SetDefaults() {
+	if f.Page <= 0 {
+		f.Page = 1
+	}
+	if f.Limit <= 0 {
+		f.Limit = 20
+	}
+	f.Offset = (f.Page - 1) * f.Limit
+}

--- a/internal/domains/portal/entities/audit_filter.go
+++ b/internal/domains/portal/entities/audit_filter.go
@@ -13,6 +13,7 @@ type AuditFilter struct {
 	Username  string
 	UserGroup string
 	IPAddress string
+	Resource  string
 	FromTime  *time.Time
 	ToTime    *time.Time
 	Page      int

--- a/internal/domains/portal/entities/audit_log.go
+++ b/internal/domains/portal/entities/audit_log.go
@@ -13,7 +13,7 @@ type AuditLog struct {
 	Username     string
 	UserGroup    string
 	Action       string
-	Resource     string
+	ResourceType string
 	ResourceName string
 	IPAddress    string
 	Success      bool

--- a/internal/domains/portal/entities/audit_log.go
+++ b/internal/domains/portal/entities/audit_log.go
@@ -10,6 +10,8 @@ import (
 type AuditLog struct {
 	ID        uuid.UUID
 	UserID    uuid.UUID
+	Username  string
+	UserGroup string
 	Action    string
 	Resource  string
 	Success   bool

--- a/internal/domains/portal/entities/audit_log.go
+++ b/internal/domains/portal/entities/audit_log.go
@@ -8,12 +8,18 @@ import (
 
 // AuditLog records portal activities.
 type AuditLog struct {
-	ID        uuid.UUID
-	UserID    uuid.UUID
-	Username  string
-	UserGroup string
-	Action    string
-	Resource  string
-	Success   bool
-	CreatedAt time.Time
+	ID           uuid.UUID
+	UserID       uuid.UUID
+	Username     string
+	UserGroup    string
+	Action       string
+	Resource     string
+	ResourceID   string
+	ResourceName string
+	IPAddress    string
+	UserAgent    string
+	ErrorMessage string
+	DurationMs   int
+	Success      bool
+	CreatedAt    time.Time
 }

--- a/internal/domains/portal/entities/audit_log.go
+++ b/internal/domains/portal/entities/audit_log.go
@@ -14,12 +14,8 @@ type AuditLog struct {
 	UserGroup    string
 	Action       string
 	Resource     string
-	ResourceID   string
 	ResourceName string
 	IPAddress    string
-	UserAgent    string
-	ErrorMessage string
-	DurationMs   int
 	Success      bool
 	CreatedAt    time.Time
 }

--- a/internal/domains/portal/entities/ldap_config.go
+++ b/internal/domains/portal/entities/ldap_config.go
@@ -1,0 +1,18 @@
+package entities
+
+import (
+	"github.com/google/uuid"
+	"time"
+)
+
+// LDAPConfig stores connection info for an LDAP server
+type LDAPConfig struct {
+	ID           uuid.UUID
+	Host         string
+	Port         int
+	BindDN       string
+	BindPassword string
+	BaseDN       string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}

--- a/internal/domains/portal/entities/openvpn_config.go
+++ b/internal/domains/portal/entities/openvpn_config.go
@@ -1,0 +1,17 @@
+package entities
+
+import (
+	"github.com/google/uuid"
+	"time"
+)
+
+// OpenVPNConfig stores connection info for the OpenVPN XML-RPC service
+type OpenVPNConfig struct {
+	ID        uuid.UUID
+	Host      string
+	Username  string
+	Password  string
+	Port      int
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}

--- a/internal/domains/portal/entities/portal_group.go
+++ b/internal/domains/portal/entities/portal_group.go
@@ -17,5 +17,24 @@ type PortalGroup struct {
 	UpdatedAt   time.Time
 }
 
+// GroupFilter defines optional filters and pagination for listing groups.
+type GroupFilter struct {
+	Name   string
+	Page   int
+	Limit  int
+	Offset int
+}
+
+// SetDefaults ensures pagination defaults and calculates the offset.
+func (f *GroupFilter) SetDefaults() {
+	if f.Page <= 0 {
+		f.Page = 1
+	}
+	if f.Limit <= 0 {
+		f.Limit = 20
+	}
+	f.Offset = (f.Page - 1) * f.Limit
+}
+
 // Backward compatibility alias
 type Group = PortalGroup

--- a/internal/domains/portal/entities/portal_group.go
+++ b/internal/domains/portal/entities/portal_group.go
@@ -11,7 +11,7 @@ type PortalGroup struct {
 	ID          uuid.UUID
 	Name        string
 	DisplayName string
-	Permissions []Permission
+	Permissions []*Permission
 	IsActive    bool
 	CreatedAt   time.Time
 	UpdatedAt   time.Time

--- a/internal/domains/portal/entities/portal_user.go
+++ b/internal/domains/portal/entities/portal_user.go
@@ -18,3 +18,24 @@ type PortalUser struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
+
+// UserFilter defines optional filters and pagination for listing users.
+type UserFilter struct {
+	Username string
+	Email    string
+	GroupID  uuid.UUID
+	Page     int
+	Limit    int
+	Offset   int
+}
+
+// SetDefaults ensures pagination defaults and calculates the offset.
+func (f *UserFilter) SetDefaults() {
+	if f.Page <= 0 {
+		f.Page = 1
+	}
+	if f.Limit <= 0 {
+		f.Limit = 20
+	}
+	f.Offset = (f.Page - 1) * f.Limit
+}

--- a/internal/domains/portal/handlers/audit_handler.go
+++ b/internal/domains/portal/handlers/audit_handler.go
@@ -40,7 +40,7 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 	logs, _ := h.uc.List(c.Request.Context())
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)
-	_ = w.Write([]string{"id", "user_id", "username", "user_group", "action", "resource", "success", "created_at"})
+	_ = w.Write([]string{"id", "user_id", "username", "user_group", "action", "resource", "ip_address", "user_agent", "duration_ms", "success", "created_at"})
 	for _, l := range logs {
 		uid := l.UserID.String()
 		_ = w.Write([]string{
@@ -50,6 +50,9 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 			l.UserGroup,
 			l.Action,
 			l.Resource,
+			l.IPAddress,
+			l.UserAgent,
+			strconv.Itoa(l.DurationMs),
 			strconv.FormatBool(l.Success),
 			l.CreatedAt.Format(time.RFC3339),
 		})

--- a/internal/domains/portal/handlers/audit_handler.go
+++ b/internal/domains/portal/handlers/audit_handler.go
@@ -40,12 +40,14 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 	logs, _ := h.uc.List(c.Request.Context())
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)
-	_ = w.Write([]string{"id", "user_id", "action", "resource", "success", "created_at"})
+	_ = w.Write([]string{"id", "user_id", "username", "user_group", "action", "resource", "success", "created_at"})
 	for _, l := range logs {
 		uid := l.UserID.String()
 		_ = w.Write([]string{
 			l.ID.String(),
 			uid,
+			l.Username,
+			l.UserGroup,
 			l.Action,
 			l.Resource,
 			strconv.FormatBool(l.Success),

--- a/internal/domains/portal/handlers/audit_handler.go
+++ b/internal/domains/portal/handlers/audit_handler.go
@@ -40,7 +40,7 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 	logs, _ := h.uc.List(c.Request.Context())
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)
-	_ = w.Write([]string{"id", "user_id", "username", "user_group", "action", "resource", "ip_address", "user_agent", "duration_ms", "success", "created_at"})
+	_ = w.Write([]string{"id", "user_id", "username", "user_group", "action", "resource", "resource_name", "ip_address", "success", "created_at"})
 	for _, l := range logs {
 		uid := l.UserID.String()
 		_ = w.Write([]string{
@@ -50,9 +50,8 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 			l.UserGroup,
 			l.Action,
 			l.Resource,
+			l.ResourceName,
 			l.IPAddress,
-			l.UserAgent,
-			strconv.Itoa(l.DurationMs),
 			strconv.FormatBool(l.Success),
 			l.CreatedAt.Format(time.RFC3339),
 		})

--- a/internal/domains/portal/handlers/audit_handler.go
+++ b/internal/domains/portal/handlers/audit_handler.go
@@ -40,7 +40,7 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 	logs, _ := h.uc.List(c.Request.Context())
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)
-	_ = w.Write([]string{"id", "user_id", "username", "user_group", "action", "resource", "resource_name", "ip_address", "success", "created_at"})
+	_ = w.Write([]string{"id", "user_id", "username", "user_group", "action", "resource_type", "resource_name", "ip_address", "success", "created_at"})
 	for _, l := range logs {
 		uid := l.UserID.String()
 		_ = w.Write([]string{
@@ -49,7 +49,7 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 			l.Username,
 			l.UserGroup,
 			l.Action,
-			l.Resource,
+			l.ResourceType,
 			l.ResourceName,
 			l.IPAddress,
 			strconv.FormatBool(l.Success),

--- a/internal/domains/portal/handlers/audit_handler.go
+++ b/internal/domains/portal/handlers/audit_handler.go
@@ -23,7 +23,14 @@ func NewAuditHandler(u usecases.AuditUsecase) *AuditHandler { return &AuditHandl
 // @Tags Audit
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {array} entities.AuditLog
+// @Param username query string false "Filter by username"
+// @Param group query string false "Filter by group"
+// @Param ip query string false "Filter by IP address"
+// @Param from query string false "Start date" Format(date)
+// @Param to query string false "End date" Format(date)
+// @Param page query int false "Page number" default(1)
+// @Param limit query int false "Items per page" default(20)
+// @Success 200 {object} response.SuccessResponse{data=[]entities.AuditLog}
 // @Router /api/portal/audit/logs [get]
 type auditQuery struct {
 	Username string     `form:"username"`
@@ -55,8 +62,13 @@ func (h *AuditHandler) GetAuditLogs(c *gin.Context) {
 // @Summary Export audit logs
 // @Tags Audit
 // @Security BearerAuth
-// @Produce json
-// @Success 200 {string} string "not implemented"
+// @Produce text/csv
+// @Param username query string false "Filter by username"
+// @Param group query string false "Filter by group"
+// @Param ip query string false "Filter by IP address"
+// @Param from query string false "Start date" Format(date)
+// @Param to query string false "End date" Format(date)
+// @Success 200 {string} string "CSV file"
 // @Router /api/portal/audit/logs/export [get]
 func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 	var q auditQuery
@@ -97,7 +109,12 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 // @Tags Audit
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {string} string "not implemented"
+// @Param username query string false "Filter by username"
+// @Param group query string false "Filter by group"
+// @Param ip query string false "Filter by IP address"
+// @Param from query string false "Start date" Format(date)
+// @Param to query string false "End date" Format(date)
+// @Success 200 {object} response.SuccessResponse{data=map[string]int}
 // @Router /api/portal/audit/stats [get]
 func (h *AuditHandler) GetAuditStats(c *gin.Context) {
 	var q auditQuery

--- a/internal/domains/portal/handlers/audit_handler.go
+++ b/internal/domains/portal/handlers/audit_handler.go
@@ -36,6 +36,7 @@ type auditQuery struct {
 	Username string     `form:"username"`
 	Group    string     `form:"group"`
 	IP       string     `form:"ip"`
+	Resource string     `form:"resource"`
 	From     *time.Time `form:"from" time_format:"2006-01-02"`
 	To       *time.Time `form:"to" time_format:"2006-01-02"`
 	Page     int        `form:"page,default=1"`
@@ -49,6 +50,7 @@ func (h *AuditHandler) GetAuditLogs(c *gin.Context) {
 		Username:  q.Username,
 		UserGroup: q.Group,
 		IPAddress: q.IP,
+		Resource:  q.Resource,
 		FromTime:  q.From,
 		ToTime:    q.To,
 		Page:      q.Page,
@@ -77,6 +79,7 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 		Username:  q.Username,
 		UserGroup: q.Group,
 		IPAddress: q.IP,
+		Resource:  q.Resource,
 		FromTime:  q.From,
 		ToTime:    q.To,
 	}
@@ -119,7 +122,7 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 func (h *AuditHandler) GetAuditStats(c *gin.Context) {
 	var q auditQuery
 	_ = c.ShouldBindQuery(&q)
-	filter := &entities.AuditFilter{Username: q.Username, UserGroup: q.Group, IPAddress: q.IP, FromTime: q.From, ToTime: q.To}
+	filter := &entities.AuditFilter{Username: q.Username, UserGroup: q.Group, IPAddress: q.IP, Resource: q.Resource, FromTime: q.From, ToTime: q.To}
 	logs, _, _ := h.uc.List(c.Request.Context(), filter)
 	var total, success, failed int
 	for _, l := range logs {

--- a/internal/domains/portal/handlers/config_handler.go
+++ b/internal/domains/portal/handlers/config_handler.go
@@ -39,6 +39,30 @@ func (h *ConfigHandler) GetOpenVPNConfig(c *gin.Context) {
 	httpresp.RespondWithSuccess(c, nethttp.StatusOK, cfg)
 }
 
+// TestOpenVPN godoc
+// @Summary Test OpenVPN connection
+// @Tags Connections
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param request body dto.OpenVPNConfigRequest true "OpenVPN config"
+// @Success 200 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Router /api/portal/connections/openvpn/test [post]
+func (h *ConfigHandler) TestOpenVPN(c *gin.Context) {
+	var req dto.OpenVPNConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpresp.RespondWithBadRequest(c, "invalid request")
+		return
+	}
+	cfg := &entities.OpenVPNConfig{Host: req.Host, Username: req.Username, Password: req.Password, Port: req.Port}
+	if err := h.uc.TestOpenVPN(c.Request.Context(), cfg); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	httpresp.RespondWithMessage(c, nethttp.StatusOK, "ok")
+}
+
 // CreateOpenVPNConfig godoc
 // @Summary Create OpenVPN connection
 // @Tags Connections
@@ -158,6 +182,30 @@ func (h *ConfigHandler) GetLDAPConfig(c *gin.Context) {
 		return
 	}
 	httpresp.RespondWithSuccess(c, nethttp.StatusOK, cfg)
+}
+
+// TestLDAP godoc
+// @Summary Test LDAP connection
+// @Tags Connections
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param request body dto.LDAPConfigRequest true "LDAP config"
+// @Success 200 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Router /api/portal/connections/ldap/test [post]
+func (h *ConfigHandler) TestLDAP(c *gin.Context) {
+	var req dto.LDAPConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpresp.RespondWithBadRequest(c, "invalid request")
+		return
+	}
+	cfg := &entities.LDAPConfig{Host: req.Host, Port: req.Port, BindDN: req.BindDN, BindPassword: req.BindPassword, BaseDN: req.BaseDN}
+	if err := h.uc.TestLDAP(c.Request.Context(), cfg); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	httpresp.RespondWithMessage(c, nethttp.StatusOK, "ok")
 }
 
 // CreateLDAPConfig godoc

--- a/internal/domains/portal/handlers/config_handler.go
+++ b/internal/domains/portal/handlers/config_handler.go
@@ -62,6 +62,24 @@ func (h *ConfigHandler) UpdateOpenVPNConfig(c *gin.Context) {
 	h.CreateOpenVPNConfig(c)
 }
 
+// DeleteOpenVPNConfig godoc
+// @Summary Delete OpenVPN connection
+// @Tags Connections
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {object} response.SuccessResponse
+// @Router /api/portal/connections/openvpn [delete]
+func (h *ConfigHandler) DeleteOpenVPNConfig(c *gin.Context) {
+	if err := h.uc.DeleteOpenVPN(c.Request.Context()); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	if h.reload != nil {
+		h.reload()
+	}
+	httpresp.RespondWithMessage(c, nethttp.StatusOK, "deleted")
+}
+
 // CreateLDAPConfig godoc
 // @Summary Set LDAP connection
 // @Tags Connections
@@ -105,4 +123,22 @@ func (h *ConfigHandler) CreateLDAPConfig(c *gin.Context) {
 // @Router /api/portal/connections/ldap [put]
 func (h *ConfigHandler) UpdateLDAPConfig(c *gin.Context) {
 	h.CreateLDAPConfig(c)
+}
+
+// DeleteLDAPConfig godoc
+// @Summary Delete LDAP connection
+// @Tags Connections
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {object} response.SuccessResponse
+// @Router /api/portal/connections/ldap [delete]
+func (h *ConfigHandler) DeleteLDAPConfig(c *gin.Context) {
+	if err := h.uc.DeleteLDAP(c.Request.Context()); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	if h.reload != nil {
+		h.reload()
+	}
+	httpresp.RespondWithMessage(c, nethttp.StatusOK, "deleted")
 }

--- a/internal/domains/portal/handlers/config_handler.go
+++ b/internal/domains/portal/handlers/config_handler.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"github.com/gin-gonic/gin"
+	nethttp "net/http"
+	"system-portal/internal/domains/portal/dto"
+	"system-portal/internal/domains/portal/entities"
+	"system-portal/internal/domains/portal/usecases"
+	httpresp "system-portal/internal/shared/response"
+)
+
+type ConfigHandler struct{ uc usecases.ConfigUsecase }
+
+func NewConfigHandler(u usecases.ConfigUsecase) *ConfigHandler { return &ConfigHandler{uc: u} }
+
+// CreateOpenVPNConfig godoc
+// @Summary Set OpenVPN connection
+// @Tags Connections
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param request body dto.OpenVPNConfigRequest true "OpenVPN config"
+// @Success 201 {object} response.SuccessResponse
+// @Router /api/portal/connections/openvpn [post]
+func (h *ConfigHandler) CreateOpenVPNConfig(c *gin.Context) {
+	var req dto.OpenVPNConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpresp.RespondWithBadRequest(c, "invalid request")
+		return
+	}
+	cfg := &entities.OpenVPNConfig{
+		Host:     req.Host,
+		Username: req.Username,
+		Password: req.Password,
+		Port:     req.Port,
+	}
+	if err := h.uc.SetOpenVPN(c.Request.Context(), cfg); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	httpresp.RespondWithMessage(c, nethttp.StatusCreated, "saved")
+}
+
+// UpdateOpenVPNConfig godoc
+// @Summary Update OpenVPN connection
+// @Tags Connections
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param request body dto.OpenVPNConfigRequest true "OpenVPN config"
+// @Success 200 {object} response.SuccessResponse
+// @Router /api/portal/connections/openvpn [put]
+func (h *ConfigHandler) UpdateOpenVPNConfig(c *gin.Context) {
+	h.CreateOpenVPNConfig(c)
+}
+
+// CreateLDAPConfig godoc
+// @Summary Set LDAP connection
+// @Tags Connections
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param request body dto.LDAPConfigRequest true "LDAP config"
+// @Success 201 {object} response.SuccessResponse
+// @Router /api/portal/connections/ldap [post]
+func (h *ConfigHandler) CreateLDAPConfig(c *gin.Context) {
+	var req dto.LDAPConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpresp.RespondWithBadRequest(c, "invalid request")
+		return
+	}
+	cfg := &entities.LDAPConfig{
+		Host:         req.Host,
+		Port:         req.Port,
+		BindDN:       req.BindDN,
+		BindPassword: req.BindPassword,
+		BaseDN:       req.BaseDN,
+	}
+	if err := h.uc.SetLDAP(c.Request.Context(), cfg); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	httpresp.RespondWithMessage(c, nethttp.StatusCreated, "saved")
+}
+
+// UpdateLDAPConfig godoc
+// @Summary Update LDAP connection
+// @Tags Connections
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param request body dto.LDAPConfigRequest true "LDAP config"
+// @Success 200 {object} response.SuccessResponse
+// @Router /api/portal/connections/ldap [put]
+func (h *ConfigHandler) UpdateLDAPConfig(c *gin.Context) {
+	h.CreateLDAPConfig(c)
+}

--- a/internal/domains/portal/handlers/config_handler.go
+++ b/internal/domains/portal/handlers/config_handler.go
@@ -9,9 +9,14 @@ import (
 	httpresp "system-portal/internal/shared/response"
 )
 
-type ConfigHandler struct{ uc usecases.ConfigUsecase }
+type ConfigHandler struct {
+	uc     usecases.ConfigUsecase
+	reload func()
+}
 
-func NewConfigHandler(u usecases.ConfigUsecase) *ConfigHandler { return &ConfigHandler{uc: u} }
+func NewConfigHandler(u usecases.ConfigUsecase, reload func()) *ConfigHandler {
+	return &ConfigHandler{uc: u, reload: reload}
+}
 
 // CreateOpenVPNConfig godoc
 // @Summary Set OpenVPN connection
@@ -37,6 +42,9 @@ func (h *ConfigHandler) CreateOpenVPNConfig(c *gin.Context) {
 	if err := h.uc.SetOpenVPN(c.Request.Context(), cfg); err != nil {
 		httpresp.RespondWithBadRequest(c, err.Error())
 		return
+	}
+	if h.reload != nil {
+		h.reload()
 	}
 	httpresp.RespondWithMessage(c, nethttp.StatusCreated, "saved")
 }
@@ -79,6 +87,9 @@ func (h *ConfigHandler) CreateLDAPConfig(c *gin.Context) {
 	if err := h.uc.SetLDAP(c.Request.Context(), cfg); err != nil {
 		httpresp.RespondWithBadRequest(c, err.Error())
 		return
+	}
+	if h.reload != nil {
+		h.reload()
 	}
 	httpresp.RespondWithMessage(c, nethttp.StatusCreated, "saved")
 }

--- a/internal/domains/portal/handlers/config_handler.go
+++ b/internal/domains/portal/handlers/config_handler.go
@@ -18,6 +18,27 @@ func NewConfigHandler(u usecases.ConfigUsecase, reload func()) *ConfigHandler {
 	return &ConfigHandler{uc: u, reload: reload}
 }
 
+// GetOpenVPNConfig godoc
+// @Summary Get OpenVPN connection
+// @Tags Connections
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {object} response.SuccessResponse{data=entities.OpenVPNConfig}
+// @Failure 404 {object} response.ErrorResponse
+// @Router /api/portal/connections/openvpn [get]
+func (h *ConfigHandler) GetOpenVPNConfig(c *gin.Context) {
+	cfg, err := h.uc.GetOpenVPN(c.Request.Context())
+	if err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	if cfg == nil {
+		httpresp.RespondWithNotFound(c, "not found")
+		return
+	}
+	httpresp.RespondWithSuccess(c, nethttp.StatusOK, cfg)
+}
+
 // CreateOpenVPNConfig godoc
 // @Summary Set OpenVPN connection
 // @Tags Connections
@@ -78,6 +99,27 @@ func (h *ConfigHandler) DeleteOpenVPNConfig(c *gin.Context) {
 		h.reload()
 	}
 	httpresp.RespondWithMessage(c, nethttp.StatusOK, "deleted")
+}
+
+// GetLDAPConfig godoc
+// @Summary Get LDAP connection
+// @Tags Connections
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {object} response.SuccessResponse{data=entities.LDAPConfig}
+// @Failure 404 {object} response.ErrorResponse
+// @Router /api/portal/connections/ldap [get]
+func (h *ConfigHandler) GetLDAPConfig(c *gin.Context) {
+	cfg, err := h.uc.GetLDAP(c.Request.Context())
+	if err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	if cfg == nil {
+		httpresp.RespondWithNotFound(c, "not found")
+		return
+	}
+	httpresp.RespondWithSuccess(c, nethttp.StatusOK, cfg)
 }
 
 // CreateLDAPConfig godoc

--- a/internal/domains/portal/handlers/dashboard_handler.go
+++ b/internal/domains/portal/handlers/dashboard_handler.go
@@ -25,8 +25,11 @@ func NewDashboardHandler(u repositories.UserRepository, a repositories.AuditRepo
 // @Success 200 {object} response.SuccessResponse{data=dto.StatsResponse}
 // @Router /api/portal/dashboard/stats [get]
 func (h *DashboardHandler) GetDashboardStats(c *gin.Context) {
-	users, _ := h.userRepo.List(c.Request.Context())
-	http.RespondWithSuccess(c, 200, dto.StatsResponse{Users: len(users)})
+	users, total, _ := h.userRepo.List(c.Request.Context(), &entities.UserFilter{})
+	if total == 0 {
+		total = len(users)
+	}
+	http.RespondWithSuccess(c, 200, dto.StatsResponse{Users: total})
 }
 
 // GetRecentActivities godoc

--- a/internal/domains/portal/handlers/dashboard_handler.go
+++ b/internal/domains/portal/handlers/dashboard_handler.go
@@ -22,7 +22,7 @@ func NewDashboardHandler(u repositories.UserRepository, a repositories.AuditRepo
 // @Tags Dashboard
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {object} dto.StatsResponse
+// @Success 200 {object} response.SuccessResponse{data=dto.StatsResponse}
 // @Router /api/portal/dashboard/stats [get]
 func (h *DashboardHandler) GetDashboardStats(c *gin.Context) {
 	users, _ := h.userRepo.List(c.Request.Context())
@@ -34,7 +34,7 @@ func (h *DashboardHandler) GetDashboardStats(c *gin.Context) {
 // @Tags Dashboard
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {array} dto.AuditResponse
+// @Success 200 {object} response.SuccessResponse{data=[]dto.AuditResponse}
 // @Router /api/portal/dashboard/activities [get]
 func (h *DashboardHandler) GetRecentActivities(c *gin.Context) {
 	filter := &entities.AuditFilter{Page: 1, Limit: 10}
@@ -58,7 +58,7 @@ func (h *DashboardHandler) GetRecentActivities(c *gin.Context) {
 // @Tags Dashboard
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {object} map[string]interface{}
+// @Success 200 {object} response.SuccessResponse{data=map[string]interface{}}
 // @Router /api/portal/dashboard/charts/users [get]
 func (h *DashboardHandler) GetUserChartData(c *gin.Context) {
 	http.RespondWithSuccess(c, 200, gin.H{})
@@ -69,7 +69,7 @@ func (h *DashboardHandler) GetUserChartData(c *gin.Context) {
 // @Tags Dashboard
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {object} map[string]interface{}
+// @Success 200 {object} response.SuccessResponse{data=map[string]interface{}}
 // @Router /api/portal/dashboard/charts/activities [get]
 func (h *DashboardHandler) GetActivityChartData(c *gin.Context) {
 	http.RespondWithSuccess(c, 200, gin.H{})

--- a/internal/domains/portal/handlers/dashboard_handler.go
+++ b/internal/domains/portal/handlers/dashboard_handler.go
@@ -39,7 +39,14 @@ func (h *DashboardHandler) GetRecentActivities(c *gin.Context) {
 	logs, _ := h.auditRepo.List(c.Request.Context())
 	resp := make([]dto.AuditResponse, 0, len(logs))
 	for _, l := range logs {
-		resp = append(resp, dto.AuditResponse{ID: l.ID, UserID: l.UserID, Action: l.Action, Resource: l.Resource, Success: l.Success})
+		resp = append(resp, dto.AuditResponse{
+			ID:           l.ID,
+			UserID:       l.UserID,
+			Action:       l.Action,
+			Resource:     l.ResourceType,
+			ResourceName: l.ResourceName,
+			Success:      l.Success,
+		})
 	}
 	http.RespondWithSuccess(c, 200, resp)
 }

--- a/internal/domains/portal/handlers/dashboard_handler.go
+++ b/internal/domains/portal/handlers/dashboard_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"github.com/gin-gonic/gin"
 	"system-portal/internal/domains/portal/dto"
+	"system-portal/internal/domains/portal/entities"
 	"system-portal/internal/domains/portal/repositories"
 	http "system-portal/internal/shared/response"
 )
@@ -36,7 +37,8 @@ func (h *DashboardHandler) GetDashboardStats(c *gin.Context) {
 // @Success 200 {array} dto.AuditResponse
 // @Router /api/portal/dashboard/activities [get]
 func (h *DashboardHandler) GetRecentActivities(c *gin.Context) {
-	logs, _ := h.auditRepo.List(c.Request.Context())
+	filter := &entities.AuditFilter{Page: 1, Limit: 10}
+	logs, _, _ := h.auditRepo.List(c.Request.Context(), filter)
 	resp := make([]dto.AuditResponse, 0, len(logs))
 	for _, l := range logs {
 		resp = append(resp, dto.AuditResponse{

--- a/internal/domains/portal/handlers/group_handler.go
+++ b/internal/domains/portal/handlers/group_handler.go
@@ -70,8 +70,64 @@ func (h *GroupHandler) CreateGroup(c *gin.Context) {
 	g.ID = uuid.New()
 	g.CreatedAt = time.Now()
 	g.UpdatedAt = time.Now()
-	h.uc.Create(c.Request.Context(), &g)
+	if err := h.uc.Create(c.Request.Context(), &g); err != nil {
+		http.RespondWithBadRequest(c, err.Error())
+		return
+	}
 	http.RespondWithMessage(c, nethttp.StatusCreated, "created")
+}
+
+// UpdateGroup godoc
+// @Summary Update portal group
+// @Tags Portal Groups
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param id path string true "Group ID"
+// @Param request body entities.PortalGroup true "Group data"
+// @Success 200 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Router /api/portal/groups/{id} [put]
+func (h *GroupHandler) UpdateGroup(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		http.RespondWithBadRequest(c, "invalid id")
+		return
+	}
+	var g entities.PortalGroup
+	if err := c.ShouldBindJSON(&g); err != nil {
+		http.RespondWithBadRequest(c, "invalid request")
+		return
+	}
+	g.ID = id
+	g.UpdatedAt = time.Now()
+	if err := h.uc.Update(c.Request.Context(), &g); err != nil {
+		http.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	http.RespondWithMessage(c, nethttp.StatusOK, "updated")
+}
+
+// DeleteGroup godoc
+// @Summary Delete portal group
+// @Tags Portal Groups
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "Group ID"
+// @Success 200 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Router /api/portal/groups/{id} [delete]
+func (h *GroupHandler) DeleteGroup(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		http.RespondWithBadRequest(c, "invalid id")
+		return
+	}
+	if err := h.uc.Delete(c.Request.Context(), id); err != nil {
+		http.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	http.RespondWithMessage(c, nethttp.StatusOK, "deleted")
 }
 
 // ListPermissions godoc

--- a/internal/domains/portal/handlers/group_handler.go
+++ b/internal/domains/portal/handlers/group_handler.go
@@ -135,7 +135,7 @@ func (h *GroupHandler) DeleteGroup(c *gin.Context) {
 // @Tags Permissions
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {object} response.SuccessResponse{data=[]entities.Permission}
+// @Success 200 {object} response.SuccessResponse{data=[]*entities.Permission}
 // @Router /api/portal/permissions [get]
 func (h *GroupHandler) ListPermissions(c *gin.Context) {
 	perms, _ := h.uc.ListPermissions(c.Request.Context())
@@ -148,7 +148,7 @@ func (h *GroupHandler) ListPermissions(c *gin.Context) {
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "Group ID"
-// @Success 200 {object} response.SuccessResponse{data=[]entities.Permission}
+// @Success 200 {object} response.SuccessResponse{data=[]*entities.Permission}
 // @Router /api/portal/groups/{id}/permissions [get]
 func (h *GroupHandler) GetGroupPermissions(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))

--- a/internal/domains/portal/handlers/group_handler.go
+++ b/internal/domains/portal/handlers/group_handler.go
@@ -20,7 +20,7 @@ func NewGroupHandler(u usecases.GroupUsecase) *GroupHandler { return &GroupHandl
 // @Tags Portal Groups
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {array} entities.PortalGroup
+// @Success 200 {object} response.SuccessResponse{data=[]entities.PortalGroup}
 // @Router /api/portal/groups [get]
 func (h *GroupHandler) ListGroups(c *gin.Context) {
 	groups, _ := h.uc.List(c.Request.Context())
@@ -33,7 +33,7 @@ func (h *GroupHandler) ListGroups(c *gin.Context) {
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "Group ID"
-// @Success 200 {object} entities.PortalGroup
+// @Success 200 {object} response.SuccessResponse{data=entities.PortalGroup}
 // @Failure 400 {object} response.ErrorResponse
 // @Failure 404 {object} response.ErrorResponse
 // @Router /api/portal/groups/{id} [get]
@@ -58,7 +58,7 @@ func (h *GroupHandler) GetGroup(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param request body entities.PortalGroup true "Group data"
-// @Success 201 {string} string "created"
+// @Success 201 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
 // @Router /api/portal/groups [post]
 func (h *GroupHandler) CreateGroup(c *gin.Context) {
@@ -76,10 +76,10 @@ func (h *GroupHandler) CreateGroup(c *gin.Context) {
 
 // ListPermissions godoc
 // @Summary List permissions
-// @Tags Portal Groups
+// @Tags Permissions
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {array} entities.Permission
+// @Success 200 {object} response.SuccessResponse{data=[]entities.Permission}
 // @Router /api/portal/permissions [get]
 func (h *GroupHandler) ListPermissions(c *gin.Context) {
 	perms, _ := h.uc.ListPermissions(c.Request.Context())
@@ -88,11 +88,11 @@ func (h *GroupHandler) ListPermissions(c *gin.Context) {
 
 // GetGroupPermissions godoc
 // @Summary Get permissions for a group
-// @Tags Portal Groups
+// @Tags Permissions
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "Group ID"
-// @Success 200 {array} entities.Permission
+// @Success 200 {object} response.SuccessResponse{data=[]entities.Permission}
 // @Router /api/portal/groups/{id}/permissions [get]
 func (h *GroupHandler) GetGroupPermissions(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
@@ -110,13 +110,13 @@ type updatePermsRequest struct {
 
 // UpdateGroupPermissions godoc
 // @Summary Update group permissions
-// @Tags Portal Groups
+// @Tags Permissions
 // @Security BearerAuth
 // @Accept json
 // @Produce json
 // @Param id path string true "Group ID"
 // @Param request body updatePermsRequest true "Permission IDs"
-// @Success 200 {string} string "updated"
+// @Success 200 {object} response.SuccessResponse
 // @Router /api/portal/groups/{id}/permissions [put]
 func (h *GroupHandler) UpdateGroupPermissions(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))

--- a/internal/domains/portal/handlers/group_handler.go
+++ b/internal/domains/portal/handlers/group_handler.go
@@ -73,3 +73,62 @@ func (h *GroupHandler) CreateGroup(c *gin.Context) {
 	h.uc.Create(c.Request.Context(), &g)
 	http.RespondWithMessage(c, nethttp.StatusCreated, "created")
 }
+
+// ListPermissions godoc
+// @Summary List permissions
+// @Tags Portal Groups
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {array} entities.Permission
+// @Router /api/portal/permissions [get]
+func (h *GroupHandler) ListPermissions(c *gin.Context) {
+	perms, _ := h.uc.ListPermissions(c.Request.Context())
+	http.RespondWithSuccess(c, nethttp.StatusOK, perms)
+}
+
+// GetGroupPermissions godoc
+// @Summary Get permissions for a group
+// @Tags Portal Groups
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "Group ID"
+// @Success 200 {array} entities.Permission
+// @Router /api/portal/groups/{id}/permissions [get]
+func (h *GroupHandler) GetGroupPermissions(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		http.RespondWithBadRequest(c, "invalid id")
+		return
+	}
+	perms, _ := h.uc.GetPermissions(c.Request.Context(), id)
+	http.RespondWithSuccess(c, nethttp.StatusOK, perms)
+}
+
+type updatePermsRequest struct {
+	PermissionIDs []uuid.UUID `json:"permission_ids"`
+}
+
+// UpdateGroupPermissions godoc
+// @Summary Update group permissions
+// @Tags Portal Groups
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param id path string true "Group ID"
+// @Param request body updatePermsRequest true "Permission IDs"
+// @Success 200 {string} string "updated"
+// @Router /api/portal/groups/{id}/permissions [put]
+func (h *GroupHandler) UpdateGroupPermissions(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		http.RespondWithBadRequest(c, "invalid id")
+		return
+	}
+	var req updatePermsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		http.RespondWithBadRequest(c, "invalid request")
+		return
+	}
+	h.uc.UpdatePermissions(c.Request.Context(), id, req.PermissionIDs)
+	http.RespondWithMessage(c, nethttp.StatusOK, "updated")
+}

--- a/internal/domains/portal/handlers/group_handler.go
+++ b/internal/domains/portal/handlers/group_handler.go
@@ -22,9 +22,18 @@ func NewGroupHandler(u usecases.GroupUsecase) *GroupHandler { return &GroupHandl
 // @Produce json
 // @Success 200 {object} response.SuccessResponse{data=[]entities.PortalGroup}
 // @Router /api/portal/groups [get]
+type groupQuery struct {
+	Name  string `form:"name"`
+	Page  int    `form:"page,default=1"`
+	Limit int    `form:"limit,default=20"`
+}
+
 func (h *GroupHandler) ListGroups(c *gin.Context) {
-	groups, _ := h.uc.List(c.Request.Context())
-	http.RespondWithSuccess(c, nethttp.StatusOK, groups)
+	var q groupQuery
+	_ = c.ShouldBindQuery(&q)
+	filter := &entities.GroupFilter{Name: q.Name, Page: q.Page, Limit: q.Limit}
+	groups, total, _ := h.uc.List(c.Request.Context(), filter)
+	http.RespondWithSuccess(c, nethttp.StatusOK, gin.H{"groups": groups, "total": total, "page": filter.Page, "limit": filter.Limit})
 }
 
 // GetGroup godoc

--- a/internal/domains/portal/handlers/group_handler.go
+++ b/internal/domains/portal/handlers/group_handler.go
@@ -185,6 +185,9 @@ func (h *GroupHandler) UpdateGroupPermissions(c *gin.Context) {
 		http.RespondWithBadRequest(c, "invalid request")
 		return
 	}
-	h.uc.UpdatePermissions(c.Request.Context(), id, req.PermissionIDs)
+	if err := h.uc.UpdatePermissions(c.Request.Context(), id, req.PermissionIDs); err != nil {
+		http.RespondWithBadRequest(c, err.Error())
+		return
+	}
 	http.RespondWithMessage(c, nethttp.StatusOK, "updated")
 }

--- a/internal/domains/portal/handlers/permission_handler.go
+++ b/internal/domains/portal/handlers/permission_handler.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	nethttp "net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"system-portal/internal/domains/portal/entities"
+	"system-portal/internal/domains/portal/usecases"
+	httpresp "system-portal/internal/shared/response"
+)
+
+type PermissionHandler struct{ uc usecases.PermissionUsecase }
+
+func NewPermissionHandler(u usecases.PermissionUsecase) *PermissionHandler {
+	return &PermissionHandler{uc: u}
+}
+
+func (h *PermissionHandler) ListPermissions(c *gin.Context) {
+	perms, _ := h.uc.List(c.Request.Context())
+	httpresp.RespondWithSuccess(c, nethttp.StatusOK, perms)
+}
+
+func (h *PermissionHandler) CreatePermission(c *gin.Context) {
+	var p entities.Permission
+	if err := c.ShouldBindJSON(&p); err != nil {
+		httpresp.RespondWithBadRequest(c, "invalid request")
+		return
+	}
+	p.ID = uuid.New()
+	h.uc.Create(c.Request.Context(), &p)
+	httpresp.RespondWithMessage(c, nethttp.StatusCreated, "created")
+}
+
+func (h *PermissionHandler) UpdatePermission(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpresp.RespondWithBadRequest(c, "invalid id")
+		return
+	}
+	var p entities.Permission
+	if err := c.ShouldBindJSON(&p); err != nil {
+		httpresp.RespondWithBadRequest(c, "invalid request")
+		return
+	}
+	p.ID = id
+	h.uc.Update(c.Request.Context(), &p)
+	httpresp.RespondWithMessage(c, nethttp.StatusOK, "updated")
+}
+
+func (h *PermissionHandler) DeletePermission(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httpresp.RespondWithBadRequest(c, "invalid id")
+		return
+	}
+	h.uc.Delete(c.Request.Context(), id)
+	httpresp.RespondWithMessage(c, nethttp.StatusOK, "deleted")
+}

--- a/internal/domains/portal/handlers/permission_handler.go
+++ b/internal/domains/portal/handlers/permission_handler.go
@@ -21,7 +21,7 @@ func NewPermissionHandler(u usecases.PermissionUsecase) *PermissionHandler {
 // @Tags Permissions
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {object} response.SuccessResponse{data=[]entities.Permission}
+// @Success 200 {object} response.SuccessResponse{data=[]*entities.Permission}
 // @Router /api/portal/permissions [get]
 func (h *PermissionHandler) ListPermissions(c *gin.Context) {
 	perms, _ := h.uc.List(c.Request.Context())

--- a/internal/domains/portal/handlers/permission_handler.go
+++ b/internal/domains/portal/handlers/permission_handler.go
@@ -24,7 +24,11 @@ func NewPermissionHandler(u usecases.PermissionUsecase) *PermissionHandler {
 // @Success 200 {object} response.SuccessResponse{data=[]*entities.Permission}
 // @Router /api/portal/permissions [get]
 func (h *PermissionHandler) ListPermissions(c *gin.Context) {
-	perms, _ := h.uc.List(c.Request.Context())
+	perms, err := h.uc.List(c.Request.Context())
+	if err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
 	httpresp.RespondWithSuccess(c, nethttp.StatusOK, perms)
 }
 
@@ -45,7 +49,10 @@ func (h *PermissionHandler) CreatePermission(c *gin.Context) {
 		return
 	}
 	p.ID = uuid.New()
-	h.uc.Create(c.Request.Context(), &p)
+	if err := h.uc.Create(c.Request.Context(), &p); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
 	httpresp.RespondWithMessage(c, nethttp.StatusCreated, "created")
 }
 
@@ -72,7 +79,10 @@ func (h *PermissionHandler) UpdatePermission(c *gin.Context) {
 		return
 	}
 	p.ID = id
-	h.uc.Update(c.Request.Context(), &p)
+	if err := h.uc.Update(c.Request.Context(), &p); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
 	httpresp.RespondWithMessage(c, nethttp.StatusOK, "updated")
 }
 
@@ -91,6 +101,9 @@ func (h *PermissionHandler) DeletePermission(c *gin.Context) {
 		httpresp.RespondWithBadRequest(c, "invalid id")
 		return
 	}
-	h.uc.Delete(c.Request.Context(), id)
+	if err := h.uc.Delete(c.Request.Context(), id); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
 	httpresp.RespondWithMessage(c, nethttp.StatusOK, "deleted")
 }

--- a/internal/domains/portal/handlers/permission_handler.go
+++ b/internal/domains/portal/handlers/permission_handler.go
@@ -16,11 +16,28 @@ func NewPermissionHandler(u usecases.PermissionUsecase) *PermissionHandler {
 	return &PermissionHandler{uc: u}
 }
 
+// ListPermissions godoc
+// @Summary List permissions
+// @Tags Permissions
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {object} response.SuccessResponse{data=[]entities.Permission}
+// @Router /api/portal/permissions [get]
 func (h *PermissionHandler) ListPermissions(c *gin.Context) {
 	perms, _ := h.uc.List(c.Request.Context())
 	httpresp.RespondWithSuccess(c, nethttp.StatusOK, perms)
 }
 
+// CreatePermission godoc
+// @Summary Create permission
+// @Tags Permissions
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param request body entities.Permission true "Permission data"
+// @Success 201 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Router /api/portal/permissions [post]
 func (h *PermissionHandler) CreatePermission(c *gin.Context) {
 	var p entities.Permission
 	if err := c.ShouldBindJSON(&p); err != nil {
@@ -32,6 +49,17 @@ func (h *PermissionHandler) CreatePermission(c *gin.Context) {
 	httpresp.RespondWithMessage(c, nethttp.StatusCreated, "created")
 }
 
+// UpdatePermission godoc
+// @Summary Update permission
+// @Tags Permissions
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param id path string true "Permission ID"
+// @Param request body entities.Permission true "Permission data"
+// @Success 200 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Router /api/portal/permissions/{id} [put]
 func (h *PermissionHandler) UpdatePermission(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -48,6 +76,15 @@ func (h *PermissionHandler) UpdatePermission(c *gin.Context) {
 	httpresp.RespondWithMessage(c, nethttp.StatusOK, "updated")
 }
 
+// DeletePermission godoc
+// @Summary Delete permission
+// @Tags Permissions
+// @Security BearerAuth
+// @Produce json
+// @Param id path string true "Permission ID"
+// @Success 200 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Router /api/portal/permissions/{id} [delete]
 func (h *PermissionHandler) DeletePermission(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {

--- a/internal/domains/portal/handlers/user_handler.go
+++ b/internal/domains/portal/handlers/user_handler.go
@@ -71,7 +71,10 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	}
-	h.uc.Create(c.Request.Context(), user)
+	if err := h.uc.Create(c.Request.Context(), user); err != nil {
+		http.RespondWithBadRequest(c, err.Error())
+		return
+	}
 	http.RespondWithMessage(c, nethttp.StatusCreated, "created")
 }
 
@@ -140,7 +143,10 @@ func (h *UserHandler) UpdateUser(c *gin.Context) {
 		IsActive:  true,
 		UpdatedAt: time.Now(),
 	}
-	h.uc.Update(c.Request.Context(), user)
+	if err := h.uc.Update(c.Request.Context(), user); err != nil {
+		http.RespondWithBadRequest(c, err.Error())
+		return
+	}
 	http.RespondWithMessage(c, nethttp.StatusOK, "updated")
 }
 
@@ -160,7 +166,10 @@ func (h *UserHandler) DeleteUser(c *gin.Context) {
 		http.RespondWithBadRequest(c, "invalid id")
 		return
 	}
-	h.uc.Delete(c.Request.Context(), id)
+	if err := h.uc.Delete(c.Request.Context(), id); err != nil {
+		http.RespondWithBadRequest(c, err.Error())
+		return
+	}
 	http.RespondWithMessage(c, nethttp.StatusOK, "deleted")
 }
 

--- a/internal/domains/portal/handlers/user_handler.go
+++ b/internal/domains/portal/handlers/user_handler.go
@@ -50,12 +50,12 @@ func (h *UserHandler) ListUsers(c *gin.Context) {
 // @Security BearerAuth
 // @Accept json
 // @Produce json
-// @Param request body dto.PortalUserUpdateRequest true "User data"
+// @Param request body dto.PortalUserRequest true "User data"
 // @Success 201 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
 // @Router /api/portal/users [post]
 func (h *UserHandler) CreateUser(c *gin.Context) {
-	var req dto.PortalUserUpdateRequest
+	var req dto.PortalUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		http.RespondWithBadRequest(c, "invalid request")
 		return

--- a/internal/domains/portal/handlers/user_handler.go
+++ b/internal/domains/portal/handlers/user_handler.go
@@ -50,12 +50,12 @@ func (h *UserHandler) ListUsers(c *gin.Context) {
 // @Security BearerAuth
 // @Accept json
 // @Produce json
-// @Param request body dto.PortalUserRequest true "User data"
+// @Param request body dto.PortalUserUpdateRequest true "User data"
 // @Success 201 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
 // @Router /api/portal/users [post]
 func (h *UserHandler) CreateUser(c *gin.Context) {
-	var req dto.PortalUserRequest
+	var req dto.PortalUserUpdateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		http.RespondWithBadRequest(c, "invalid request")
 		return
@@ -135,8 +135,6 @@ func (h *UserHandler) UpdateUser(c *gin.Context) {
 	}
 	user := &entities.PortalUser{
 		ID:        id,
-		Username:  req.Username,
-		Email:     req.Email,
 		FullName:  req.FullName,
 		Password:  req.Password,
 		GroupID:   req.GroupID,

--- a/internal/domains/portal/handlers/user_handler.go
+++ b/internal/domains/portal/handlers/user_handler.go
@@ -25,7 +25,7 @@ func NewUserHandler(u usecases.UserUsecase) *UserHandler { return &UserHandler{u
 // @Tags Portal Users
 // @Security BearerAuth
 // @Produce json
-// @Success 200 {array} dto.PortalUserResponse
+// @Success 200 {object} response.SuccessResponse{data=[]dto.PortalUserResponse}
 // @Router /api/portal/users [get]
 func (h *UserHandler) ListUsers(c *gin.Context) {
 	users, _ := h.uc.List(c.Request.Context())
@@ -51,7 +51,7 @@ func (h *UserHandler) ListUsers(c *gin.Context) {
 // @Accept json
 // @Produce json
 // @Param request body dto.PortalUserRequest true "User data"
-// @Success 201 {string} string "created"
+// @Success 201 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
 // @Router /api/portal/users [post]
 func (h *UserHandler) CreateUser(c *gin.Context) {
@@ -82,7 +82,7 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "User ID"
-// @Success 200 {object} dto.PortalUserResponse
+// @Success 200 {object} response.SuccessResponse{data=dto.PortalUserResponse}
 // @Failure 400 {object} response.ErrorResponse
 // @Failure 404 {object} response.ErrorResponse
 // @Router /api/portal/users/{id} [get]
@@ -116,7 +116,7 @@ func (h *UserHandler) GetUser(c *gin.Context) {
 // @Produce json
 // @Param id path string true "User ID"
 // @Param request body dto.PortalUserRequest true "User data"
-// @Success 200 {string} string "updated"
+// @Success 200 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
 // @Router /api/portal/users/{id} [put]
 func (h *UserHandler) UpdateUser(c *gin.Context) {
@@ -151,7 +151,7 @@ func (h *UserHandler) UpdateUser(c *gin.Context) {
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "User ID"
-// @Success 200 {string} string "deleted"
+// @Success 200 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
 // @Router /api/portal/users/{id} [delete]
 func (h *UserHandler) DeleteUser(c *gin.Context) {
@@ -170,7 +170,7 @@ func (h *UserHandler) DeleteUser(c *gin.Context) {
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "User ID"
-// @Success 200 {string} string "ok"
+// @Success 200 {object} response.SuccessResponse
 // @Router /api/portal/users/{id}/activate [put]
 func (h *UserHandler) ActivateUser(c *gin.Context) { http.RespondWithMessage(c, 200, "ok") }
 
@@ -180,7 +180,7 @@ func (h *UserHandler) ActivateUser(c *gin.Context) { http.RespondWithMessage(c, 
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "User ID"
-// @Success 200 {string} string "ok"
+// @Success 200 {object} response.SuccessResponse
 // @Router /api/portal/users/{id}/deactivate [put]
 func (h *UserHandler) DeactivateUser(c *gin.Context) { http.RespondWithMessage(c, 200, "ok") }
 
@@ -190,6 +190,6 @@ func (h *UserHandler) DeactivateUser(c *gin.Context) { http.RespondWithMessage(c
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "User ID"
-// @Success 200 {string} string "ok"
+// @Success 200 {object} response.SuccessResponse
 // @Router /api/portal/users/{id}/reset-password [put]
 func (h *UserHandler) ResetPassword(c *gin.Context) { http.RespondWithMessage(c, 200, "ok") }

--- a/internal/domains/portal/repositories/audit_repository.go
+++ b/internal/domains/portal/repositories/audit_repository.go
@@ -9,6 +9,6 @@ import (
 
 type AuditRepository interface {
 	Add(ctx context.Context, log *entities.AuditLog) error
-	List(ctx context.Context) ([]*entities.AuditLog, error)
+	List(ctx context.Context, filter *entities.AuditFilter) ([]*entities.AuditLog, int, error)
 	GetByID(ctx context.Context, id uuid.UUID) (*entities.AuditLog, error)
 }

--- a/internal/domains/portal/repositories/group_repository.go
+++ b/internal/domains/portal/repositories/group_repository.go
@@ -12,4 +12,6 @@ type GroupRepository interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*entities.PortalGroup, error)
 	GetByName(ctx context.Context, name string) (*entities.PortalGroup, error)
 	List(ctx context.Context) ([]*entities.PortalGroup, error)
+	Update(ctx context.Context, group *entities.PortalGroup) error
+	Delete(ctx context.Context, id uuid.UUID) error
 }

--- a/internal/domains/portal/repositories/group_repository.go
+++ b/internal/domains/portal/repositories/group_repository.go
@@ -10,5 +10,6 @@ import (
 type GroupRepository interface {
 	Create(ctx context.Context, group *entities.PortalGroup) error
 	GetByID(ctx context.Context, id uuid.UUID) (*entities.PortalGroup, error)
+	GetByName(ctx context.Context, name string) (*entities.PortalGroup, error)
 	List(ctx context.Context) ([]*entities.PortalGroup, error)
 }

--- a/internal/domains/portal/repositories/group_repository.go
+++ b/internal/domains/portal/repositories/group_repository.go
@@ -11,7 +11,7 @@ type GroupRepository interface {
 	Create(ctx context.Context, group *entities.PortalGroup) error
 	GetByID(ctx context.Context, id uuid.UUID) (*entities.PortalGroup, error)
 	GetByName(ctx context.Context, name string) (*entities.PortalGroup, error)
-	List(ctx context.Context) ([]*entities.PortalGroup, error)
+       List(ctx context.Context, filter *entities.GroupFilter) ([]*entities.PortalGroup, int, error)
 	Update(ctx context.Context, group *entities.PortalGroup) error
 	Delete(ctx context.Context, id uuid.UUID) error
 }

--- a/internal/domains/portal/repositories/impl/audit_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/audit_repository_pg.go
@@ -64,6 +64,11 @@ func (r *pgAuditRepo) List(ctx context.Context, f *entities.AuditFilter) ([]*ent
 		args = append(args, f.IPAddress)
 		idx++
 	}
+	if f.Resource != "" {
+		clauses = append(clauses, "resource_type=$"+strconv.Itoa(idx))
+		args = append(args, f.Resource)
+		idx++
+	}
 	if f.FromTime != nil {
 		clauses = append(clauses, "created_at >= $"+strconv.Itoa(idx))
 		args = append(args, *f.FromTime)

--- a/internal/domains/portal/repositories/impl/audit_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/audit_repository_pg.go
@@ -25,12 +25,10 @@ func (r *pgAuditRepo) Add(ctx context.Context, a *entities.AuditLog) error {
 	_, err := r.db.ExecContext(ctx,
 		`INSERT INTO audit_logs (
                         id, user_id, username, user_group, action, resource_type,
-                        resource_id, resource_name, ip_address, user_agent,
-                        success, error_message, duration_ms, created_at)
-                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)`,
+                        resource_name, ip_address, success, created_at)
+                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
 		a.ID, userID, a.Username, a.UserGroup, a.Action, a.Resource,
-		a.ResourceID, a.ResourceName, a.IPAddress, a.UserAgent,
-		a.Success, a.ErrorMessage, a.DurationMs, a.CreatedAt,
+		a.ResourceName, a.IPAddress, a.Success, a.CreatedAt,
 	)
 	return err
 }
@@ -38,8 +36,7 @@ func (r *pgAuditRepo) Add(ctx context.Context, a *entities.AuditLog) error {
 func (r *pgAuditRepo) List(ctx context.Context) ([]*entities.AuditLog, error) {
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT id, user_id, username, user_group, action, resource_type,
-                        resource_id, resource_name, ip_address, user_agent,
-                        success, error_message, duration_ms, created_at
+                        resource_name, ip_address, success, created_at
                 FROM audit_logs`)
 	if err != nil {
 		return nil, err
@@ -50,8 +47,7 @@ func (r *pgAuditRepo) List(ctx context.Context) ([]*entities.AuditLog, error) {
 		var a entities.AuditLog
 		if err := rows.Scan(
 			&a.ID, &a.UserID, &a.Username, &a.UserGroup, &a.Action, &a.Resource,
-			&a.ResourceID, &a.ResourceName, &a.IPAddress, &a.UserAgent,
-			&a.Success, &a.ErrorMessage, &a.DurationMs, &a.CreatedAt,
+			&a.ResourceName, &a.IPAddress, &a.Success, &a.CreatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -63,14 +59,12 @@ func (r *pgAuditRepo) List(ctx context.Context) ([]*entities.AuditLog, error) {
 func (r *pgAuditRepo) GetByID(ctx context.Context, id uuid.UUID) (*entities.AuditLog, error) {
 	row := r.db.QueryRowContext(ctx,
 		`SELECT id, user_id, username, user_group, action, resource_type,
-                        resource_id, resource_name, ip_address, user_agent,
-                        success, error_message, duration_ms, created_at
+                        resource_name, ip_address, success, created_at
                 FROM audit_logs WHERE id=$1`, id)
 	var a entities.AuditLog
 	err := row.Scan(
 		&a.ID, &a.UserID, &a.Username, &a.UserGroup, &a.Action, &a.Resource,
-		&a.ResourceID, &a.ResourceName, &a.IPAddress, &a.UserAgent,
-		&a.Success, &a.ErrorMessage, &a.DurationMs, &a.CreatedAt,
+		&a.ResourceName, &a.IPAddress, &a.Success, &a.CreatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil

--- a/internal/domains/portal/repositories/impl/audit_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/audit_repository_pg.go
@@ -24,10 +24,10 @@ func (r *pgAuditRepo) Add(ctx context.Context, a *entities.AuditLog) error {
 	}
 	_, err := r.db.ExecContext(ctx,
 		`INSERT INTO audit_logs (
-                        id, user_id, username, user_group, action, resource_type,
-                        resource_name, ip_address, success, created_at)
-                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-		a.ID, userID, a.Username, a.UserGroup, a.Action, a.Resource,
+                       id, user_id, username, user_group, action, resource_type,
+                       resource_name, ip_address, success, created_at)
+               VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+		a.ID, userID, a.Username, a.UserGroup, a.Action, a.ResourceType,
 		a.ResourceName, a.IPAddress, a.Success, a.CreatedAt,
 	)
 	return err
@@ -36,8 +36,8 @@ func (r *pgAuditRepo) Add(ctx context.Context, a *entities.AuditLog) error {
 func (r *pgAuditRepo) List(ctx context.Context) ([]*entities.AuditLog, error) {
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT id, user_id, username, user_group, action, resource_type,
-                        resource_name, ip_address, success, created_at
-                FROM audit_logs`)
+                       resource_name, ip_address, success, created_at
+               FROM audit_logs`)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (r *pgAuditRepo) List(ctx context.Context) ([]*entities.AuditLog, error) {
 	for rows.Next() {
 		var a entities.AuditLog
 		if err := rows.Scan(
-			&a.ID, &a.UserID, &a.Username, &a.UserGroup, &a.Action, &a.Resource,
+			&a.ID, &a.UserID, &a.Username, &a.UserGroup, &a.Action, &a.ResourceType,
 			&a.ResourceName, &a.IPAddress, &a.Success, &a.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -63,7 +63,7 @@ func (r *pgAuditRepo) GetByID(ctx context.Context, id uuid.UUID) (*entities.Audi
                 FROM audit_logs WHERE id=$1`, id)
 	var a entities.AuditLog
 	err := row.Scan(
-		&a.ID, &a.UserID, &a.Username, &a.UserGroup, &a.Action, &a.Resource,
+		&a.ID, &a.UserID, &a.Username, &a.UserGroup, &a.Action, &a.ResourceType,
 		&a.ResourceName, &a.IPAddress, &a.Success, &a.CreatedAt,
 	)
 	if err == sql.ErrNoRows {

--- a/internal/domains/portal/repositories/impl/audit_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/audit_repository_pg.go
@@ -16,10 +16,16 @@ func NewAuditRepositoryPG(db *sql.DB) repositories.AuditRepository {
 }
 
 func (r *pgAuditRepo) Add(ctx context.Context, a *entities.AuditLog) error {
+	var userID interface{}
+	if a.UserID == uuid.Nil {
+		userID = nil
+	} else {
+		userID = a.UserID
+	}
 	_, err := r.db.ExecContext(ctx,
 		`INSERT INTO audit_logs (id, user_id, action, resource_type, success, created_at)
-         VALUES ($1,$2,$3,$4,$5,$6)`,
-		a.ID, a.UserID, a.Action, a.Resource, a.Success, a.CreatedAt,
+        VALUES ($1,$2,$3,$4,$5,$6)`,
+		a.ID, userID, a.Action, a.Resource, a.Success, a.CreatedAt,
 	)
 	return err
 }

--- a/internal/domains/portal/repositories/impl/audit_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/audit_repository_pg.go
@@ -3,6 +3,9 @@ package impl
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/google/uuid"
 	"system-portal/internal/domains/portal/entities"
@@ -33,27 +36,75 @@ func (r *pgAuditRepo) Add(ctx context.Context, a *entities.AuditLog) error {
 	return err
 }
 
-func (r *pgAuditRepo) List(ctx context.Context) ([]*entities.AuditLog, error) {
-	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, user_id, username, user_group, action, resource_type,
-                       resource_name, ip_address, success, created_at
-               FROM audit_logs`)
+func (r *pgAuditRepo) List(ctx context.Context, f *entities.AuditFilter) ([]*entities.AuditLog, int, error) {
+	if f == nil {
+		f = &entities.AuditFilter{}
+	}
+	f.SetDefaults()
+
+	base := `SELECT id, user_id, username, user_group, action, resource_type,
+                        resource_name, ip_address, success, created_at FROM audit_logs`
+	countBase := `SELECT COUNT(1) FROM audit_logs`
+
+	clauses := []string{}
+	args := []interface{}{}
+	idx := 1
+	if f.Username != "" {
+		clauses = append(clauses, "username=$"+strconv.Itoa(idx))
+		args = append(args, f.Username)
+		idx++
+	}
+	if f.UserGroup != "" {
+		clauses = append(clauses, "user_group=$"+strconv.Itoa(idx))
+		args = append(args, f.UserGroup)
+		idx++
+	}
+	if f.IPAddress != "" {
+		clauses = append(clauses, "ip_address=$"+strconv.Itoa(idx))
+		args = append(args, f.IPAddress)
+		idx++
+	}
+	if f.FromTime != nil {
+		clauses = append(clauses, "created_at >= $"+strconv.Itoa(idx))
+		args = append(args, *f.FromTime)
+		idx++
+	}
+	if f.ToTime != nil {
+		clauses = append(clauses, "created_at <= $"+strconv.Itoa(idx))
+		args = append(args, *f.ToTime)
+		idx++
+	}
+
+	where := ""
+	if len(clauses) > 0 {
+		where = " WHERE " + strings.Join(clauses, " AND ")
+	}
+
+	query := base + where + " ORDER BY created_at DESC" +
+		fmt.Sprintf(" LIMIT %d OFFSET %d", f.Limit, f.Offset)
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer rows.Close()
 	var logs []*entities.AuditLog
 	for rows.Next() {
 		var a entities.AuditLog
-		if err := rows.Scan(
-			&a.ID, &a.UserID, &a.Username, &a.UserGroup, &a.Action, &a.ResourceType,
-			&a.ResourceName, &a.IPAddress, &a.Success, &a.CreatedAt,
-		); err != nil {
-			return nil, err
+		if err := rows.Scan(&a.ID, &a.UserID, &a.Username, &a.UserGroup,
+			&a.Action, &a.ResourceType, &a.ResourceName, &a.IPAddress,
+			&a.Success, &a.CreatedAt); err != nil {
+			return nil, 0, err
 		}
 		logs = append(logs, &a)
 	}
-	return logs, nil
+
+	countQuery := countBase + where
+	var total int
+	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	return logs, total, nil
 }
 
 func (r *pgAuditRepo) GetByID(ctx context.Context, id uuid.UUID) (*entities.AuditLog, error) {

--- a/internal/domains/portal/repositories/impl/audit_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/audit_repository_pg.go
@@ -23,16 +23,16 @@ func (r *pgAuditRepo) Add(ctx context.Context, a *entities.AuditLog) error {
 		userID = a.UserID
 	}
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO audit_logs (id, user_id, action, resource_type, success, created_at)
-        VALUES ($1,$2,$3,$4,$5,$6)`,
-		a.ID, userID, a.Action, a.Resource, a.Success, a.CreatedAt,
+		`INSERT INTO audit_logs (id, user_id, username, user_group, action, resource_type, success, created_at)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+		a.ID, userID, a.Username, a.UserGroup, a.Action, a.Resource, a.Success, a.CreatedAt,
 	)
 	return err
 }
 
 func (r *pgAuditRepo) List(ctx context.Context) ([]*entities.AuditLog, error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, user_id, action, resource_type, success, created_at FROM audit_logs`)
+		`SELECT id, user_id, username, user_group, action, resource_type, success, created_at FROM audit_logs`)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (r *pgAuditRepo) List(ctx context.Context) ([]*entities.AuditLog, error) {
 	var logs []*entities.AuditLog
 	for rows.Next() {
 		var a entities.AuditLog
-		if err := rows.Scan(&a.ID, &a.UserID, &a.Action, &a.Resource, &a.Success, &a.CreatedAt); err != nil {
+		if err := rows.Scan(&a.ID, &a.UserID, &a.Username, &a.UserGroup, &a.Action, &a.Resource, &a.Success, &a.CreatedAt); err != nil {
 			return nil, err
 		}
 		logs = append(logs, &a)
@@ -50,9 +50,9 @@ func (r *pgAuditRepo) List(ctx context.Context) ([]*entities.AuditLog, error) {
 
 func (r *pgAuditRepo) GetByID(ctx context.Context, id uuid.UUID) (*entities.AuditLog, error) {
 	row := r.db.QueryRowContext(ctx,
-		`SELECT id, user_id, action, resource_type, success, created_at FROM audit_logs WHERE id=$1`, id)
+		`SELECT id, user_id, username, user_group, action, resource_type, success, created_at FROM audit_logs WHERE id=$1`, id)
 	var a entities.AuditLog
-	err := row.Scan(&a.ID, &a.UserID, &a.Action, &a.Resource, &a.Success, &a.CreatedAt)
+	err := row.Scan(&a.ID, &a.UserID, &a.Username, &a.UserGroup, &a.Action, &a.Resource, &a.Success, &a.CreatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}

--- a/internal/domains/portal/repositories/impl/group_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/group_repository_pg.go
@@ -69,3 +69,16 @@ func (r *pgGroupRepo) List(ctx context.Context) ([]*entities.PortalGroup, error)
 	}
 	return groups, nil
 }
+
+func (r *pgGroupRepo) Update(ctx context.Context, g *entities.PortalGroup) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE groups SET name=$2, display_name=$3, is_active=$4, updated_at=$5 WHERE id=$1`,
+		g.ID, g.Name, g.DisplayName, g.IsActive, g.UpdatedAt,
+	)
+	return err
+}
+
+func (r *pgGroupRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM groups WHERE id=$1`, id)
+	return err
+}

--- a/internal/domains/portal/repositories/impl/group_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/group_repository_pg.go
@@ -38,6 +38,20 @@ func (r *pgGroupRepo) GetByID(ctx context.Context, id uuid.UUID) (*entities.Port
 	return &g, nil
 }
 
+func (r *pgGroupRepo) GetByName(ctx context.Context, name string) (*entities.PortalGroup, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT id, name, display_name, is_active, created_at, updated_at FROM groups WHERE name=$1`, name)
+	var g entities.PortalGroup
+	err := row.Scan(&g.ID, &g.Name, &g.DisplayName, &g.IsActive, &g.CreatedAt, &g.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &g, nil
+}
+
 func (r *pgGroupRepo) List(ctx context.Context) ([]*entities.PortalGroup, error) {
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT id, name, display_name, is_active, created_at, updated_at FROM groups`)

--- a/internal/domains/portal/repositories/impl/ldap_config_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/ldap_config_repository_pg.go
@@ -3,40 +3,71 @@ package impl
 import (
 	"context"
 	"database/sql"
+
 	"system-portal/internal/domains/portal/entities"
 	"system-portal/internal/domains/portal/repositories"
+	"system-portal/pkg/utils"
 )
 
-type pgLDAPConfigRepo struct{ db *sql.DB }
+type pgLDAPConfigRepo struct {
+	db  *sql.DB
+	key string
+}
 
-func NewLDAPConfigRepositoryPG(db *sql.DB) repositories.LDAPConfigRepository {
-	return &pgLDAPConfigRepo{db: db}
+func NewLDAPConfigRepositoryPG(db *sql.DB, key string) repositories.LDAPConfigRepository {
+	return &pgLDAPConfigRepo{db: db, key: key}
 }
 
 func (r *pgLDAPConfigRepo) Get(ctx context.Context) (*entities.LDAPConfig, error) {
 	row := r.db.QueryRowContext(ctx, `SELECT id, host, port, bind_dn, bind_password, base_dn, created_at, updated_at FROM ldap_configs LIMIT 1`)
 	var cfg entities.LDAPConfig
-	if err := row.Scan(&cfg.ID, &cfg.Host, &cfg.Port, &cfg.BindDN, &cfg.BindPassword, &cfg.BaseDN, &cfg.CreatedAt, &cfg.UpdatedAt); err != nil {
+	var encPass string
+	if err := row.Scan(&cfg.ID, &cfg.Host, &cfg.Port, &cfg.BindDN, &encPass, &cfg.BaseDN, &cfg.CreatedAt, &cfg.UpdatedAt); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
 		return nil, err
 	}
+	if r.key != "" {
+		if plain, err := utils.DecryptString(encPass, r.key); err == nil {
+			cfg.BindPassword = plain
+		} else {
+			cfg.BindPassword = encPass
+		}
+	} else {
+		cfg.BindPassword = encPass
+	}
 	return &cfg, nil
 }
 
 func (r *pgLDAPConfigRepo) Create(ctx context.Context, cfg *entities.LDAPConfig) error {
+	pass := cfg.BindPassword
+	if r.key != "" {
+		if enc, err := utils.EncryptString(cfg.BindPassword, r.key); err == nil {
+			pass = enc
+		} else {
+			return err
+		}
+	}
 	_, err := r.db.ExecContext(ctx,
 		`INSERT INTO ldap_configs (id, host, port, bind_dn, bind_password, base_dn, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$7)`,
-		cfg.ID, cfg.Host, cfg.Port, cfg.BindDN, cfg.BindPassword, cfg.BaseDN, cfg.CreatedAt,
+		cfg.ID, cfg.Host, cfg.Port, cfg.BindDN, pass, cfg.BaseDN, cfg.CreatedAt,
 	)
 	return err
 }
 
 func (r *pgLDAPConfigRepo) Update(ctx context.Context, cfg *entities.LDAPConfig) error {
+	pass := cfg.BindPassword
+	if r.key != "" {
+		if enc, err := utils.EncryptString(cfg.BindPassword, r.key); err == nil {
+			pass = enc
+		} else {
+			return err
+		}
+	}
 	_, err := r.db.ExecContext(ctx,
 		`UPDATE ldap_configs SET host=$1, port=$2, bind_dn=$3, bind_password=$4, base_dn=$5, updated_at=$6 WHERE id=$7`,
-		cfg.Host, cfg.Port, cfg.BindDN, cfg.BindPassword, cfg.BaseDN, cfg.UpdatedAt, cfg.ID,
+		cfg.Host, cfg.Port, cfg.BindDN, pass, cfg.BaseDN, cfg.UpdatedAt, cfg.ID,
 	)
 	return err
 }

--- a/internal/domains/portal/repositories/impl/ldap_config_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/ldap_config_repository_pg.go
@@ -1,0 +1,42 @@
+package impl
+
+import (
+	"context"
+	"database/sql"
+	"system-portal/internal/domains/portal/entities"
+	"system-portal/internal/domains/portal/repositories"
+)
+
+type pgLDAPConfigRepo struct{ db *sql.DB }
+
+func NewLDAPConfigRepositoryPG(db *sql.DB) repositories.LDAPConfigRepository {
+	return &pgLDAPConfigRepo{db: db}
+}
+
+func (r *pgLDAPConfigRepo) Get(ctx context.Context) (*entities.LDAPConfig, error) {
+	row := r.db.QueryRowContext(ctx, `SELECT id, host, port, bind_dn, bind_password, base_dn, created_at, updated_at FROM ldap_configs LIMIT 1`)
+	var cfg entities.LDAPConfig
+	if err := row.Scan(&cfg.ID, &cfg.Host, &cfg.Port, &cfg.BindDN, &cfg.BindPassword, &cfg.BaseDN, &cfg.CreatedAt, &cfg.UpdatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (r *pgLDAPConfigRepo) Create(ctx context.Context, cfg *entities.LDAPConfig) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO ldap_configs (id, host, port, bind_dn, bind_password, base_dn, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$7)`,
+		cfg.ID, cfg.Host, cfg.Port, cfg.BindDN, cfg.BindPassword, cfg.BaseDN, cfg.CreatedAt,
+	)
+	return err
+}
+
+func (r *pgLDAPConfigRepo) Update(ctx context.Context, cfg *entities.LDAPConfig) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE ldap_configs SET host=$1, port=$2, bind_dn=$3, bind_password=$4, base_dn=$5, updated_at=$6 WHERE id=$7`,
+		cfg.Host, cfg.Port, cfg.BindDN, cfg.BindPassword, cfg.BaseDN, cfg.UpdatedAt, cfg.ID,
+	)
+	return err
+}

--- a/internal/domains/portal/repositories/impl/ldap_config_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/ldap_config_repository_pg.go
@@ -40,3 +40,8 @@ func (r *pgLDAPConfigRepo) Update(ctx context.Context, cfg *entities.LDAPConfig)
 	)
 	return err
 }
+
+func (r *pgLDAPConfigRepo) Delete(ctx context.Context) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM ldap_configs`)
+	return err
+}

--- a/internal/domains/portal/repositories/impl/openvpn_config_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/openvpn_config_repository_pg.go
@@ -40,3 +40,8 @@ func (r *pgOpenVPNConfigRepo) Update(ctx context.Context, cfg *entities.OpenVPNC
 	)
 	return err
 }
+
+func (r *pgOpenVPNConfigRepo) Delete(ctx context.Context) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM openvpn_configs`)
+	return err
+}

--- a/internal/domains/portal/repositories/impl/openvpn_config_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/openvpn_config_repository_pg.go
@@ -3,40 +3,71 @@ package impl
 import (
 	"context"
 	"database/sql"
+
 	"system-portal/internal/domains/portal/entities"
 	"system-portal/internal/domains/portal/repositories"
+	"system-portal/pkg/utils"
 )
 
-type pgOpenVPNConfigRepo struct{ db *sql.DB }
+type pgOpenVPNConfigRepo struct {
+	db  *sql.DB
+	key string
+}
 
-func NewOpenVPNConfigRepositoryPG(db *sql.DB) repositories.OpenVPNConfigRepository {
-	return &pgOpenVPNConfigRepo{db: db}
+func NewOpenVPNConfigRepositoryPG(db *sql.DB, key string) repositories.OpenVPNConfigRepository {
+	return &pgOpenVPNConfigRepo{db: db, key: key}
 }
 
 func (r *pgOpenVPNConfigRepo) Get(ctx context.Context) (*entities.OpenVPNConfig, error) {
 	row := r.db.QueryRowContext(ctx, `SELECT id, host, username, password, port, created_at, updated_at FROM openvpn_configs LIMIT 1`)
 	var cfg entities.OpenVPNConfig
-	if err := row.Scan(&cfg.ID, &cfg.Host, &cfg.Username, &cfg.Password, &cfg.Port, &cfg.CreatedAt, &cfg.UpdatedAt); err != nil {
+	var encPass string
+	if err := row.Scan(&cfg.ID, &cfg.Host, &cfg.Username, &encPass, &cfg.Port, &cfg.CreatedAt, &cfg.UpdatedAt); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
 		return nil, err
 	}
+	if r.key != "" {
+		if plain, err := utils.DecryptString(encPass, r.key); err == nil {
+			cfg.Password = plain
+		} else {
+			cfg.Password = encPass
+		}
+	} else {
+		cfg.Password = encPass
+	}
 	return &cfg, nil
 }
 
 func (r *pgOpenVPNConfigRepo) Create(ctx context.Context, cfg *entities.OpenVPNConfig) error {
+	pass := cfg.Password
+	if r.key != "" {
+		if enc, err := utils.EncryptString(cfg.Password, r.key); err == nil {
+			pass = enc
+		} else {
+			return err
+		}
+	}
 	_, err := r.db.ExecContext(ctx,
 		`INSERT INTO openvpn_configs (id, host, username, password, port, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$6)`,
-		cfg.ID, cfg.Host, cfg.Username, cfg.Password, cfg.Port, cfg.CreatedAt,
+		cfg.ID, cfg.Host, cfg.Username, pass, cfg.Port, cfg.CreatedAt,
 	)
 	return err
 }
 
 func (r *pgOpenVPNConfigRepo) Update(ctx context.Context, cfg *entities.OpenVPNConfig) error {
+	pass := cfg.Password
+	if r.key != "" {
+		if enc, err := utils.EncryptString(cfg.Password, r.key); err == nil {
+			pass = enc
+		} else {
+			return err
+		}
+	}
 	_, err := r.db.ExecContext(ctx,
 		`UPDATE openvpn_configs SET host=$1, username=$2, password=$3, port=$4, updated_at=$5 WHERE id=$6`,
-		cfg.Host, cfg.Username, cfg.Password, cfg.Port, cfg.UpdatedAt, cfg.ID,
+		cfg.Host, cfg.Username, pass, cfg.Port, cfg.UpdatedAt, cfg.ID,
 	)
 	return err
 }

--- a/internal/domains/portal/repositories/impl/openvpn_config_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/openvpn_config_repository_pg.go
@@ -1,0 +1,42 @@
+package impl
+
+import (
+	"context"
+	"database/sql"
+	"system-portal/internal/domains/portal/entities"
+	"system-portal/internal/domains/portal/repositories"
+)
+
+type pgOpenVPNConfigRepo struct{ db *sql.DB }
+
+func NewOpenVPNConfigRepositoryPG(db *sql.DB) repositories.OpenVPNConfigRepository {
+	return &pgOpenVPNConfigRepo{db: db}
+}
+
+func (r *pgOpenVPNConfigRepo) Get(ctx context.Context) (*entities.OpenVPNConfig, error) {
+	row := r.db.QueryRowContext(ctx, `SELECT id, host, username, password, port, created_at, updated_at FROM openvpn_configs LIMIT 1`)
+	var cfg entities.OpenVPNConfig
+	if err := row.Scan(&cfg.ID, &cfg.Host, &cfg.Username, &cfg.Password, &cfg.Port, &cfg.CreatedAt, &cfg.UpdatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (r *pgOpenVPNConfigRepo) Create(ctx context.Context, cfg *entities.OpenVPNConfig) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO openvpn_configs (id, host, username, password, port, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$6)`,
+		cfg.ID, cfg.Host, cfg.Username, cfg.Password, cfg.Port, cfg.CreatedAt,
+	)
+	return err
+}
+
+func (r *pgOpenVPNConfigRepo) Update(ctx context.Context, cfg *entities.OpenVPNConfig) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE openvpn_configs SET host=$1, username=$2, password=$3, port=$4, updated_at=$5 WHERE id=$6`,
+		cfg.Host, cfg.Username, cfg.Password, cfg.Port, cfg.UpdatedAt, cfg.ID,
+	)
+	return err
+}

--- a/internal/domains/portal/repositories/impl/permission_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/permission_repository_pg.go
@@ -1,0 +1,84 @@
+package impl
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/google/uuid"
+	"system-portal/internal/domains/portal/entities"
+	"system-portal/internal/domains/portal/repositories"
+)
+
+type pgPermissionRepo struct{ db *sql.DB }
+
+func NewPermissionRepositoryPG(db *sql.DB) repositories.PermissionRepository {
+	return &pgPermissionRepo{db: db}
+}
+
+func (r *pgPermissionRepo) List(ctx context.Context) ([]*entities.Permission, error) {
+	rows, err := r.db.QueryContext(ctx, `SELECT id, resource, action, description FROM permissions`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var perms []*entities.Permission
+	for rows.Next() {
+		var p entities.Permission
+		if err := rows.Scan(&p.ID, &p.Resource, &p.Action, &p.Description); err != nil {
+			return nil, err
+		}
+		perms = append(perms, &p)
+	}
+	return perms, nil
+}
+
+func (r *pgPermissionRepo) GetByGroup(ctx context.Context, groupID uuid.UUID) ([]*entities.Permission, error) {
+	rows, err := r.db.QueryContext(ctx, `SELECT p.id, p.resource, p.action, p.description
+        FROM permissions p
+        JOIN group_permissions gp ON gp.permission_id = p.id
+        WHERE gp.group_id=$1`, groupID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var perms []*entities.Permission
+	for rows.Next() {
+		var p entities.Permission
+		if err := rows.Scan(&p.ID, &p.Resource, &p.Action, &p.Description); err != nil {
+			return nil, err
+		}
+		perms = append(perms, &p)
+	}
+	return perms, nil
+}
+
+func (r *pgPermissionRepo) SetForGroup(ctx context.Context, groupID uuid.UUID, permIDs []uuid.UUID) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM group_permissions WHERE group_id=$1`, groupID); err != nil {
+		tx.Rollback()
+		return err
+	}
+	for _, pid := range permIDs {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO group_permissions (group_id, permission_id) VALUES ($1,$2)`, groupID, pid); err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func (r *pgPermissionRepo) HasGroupPermission(ctx context.Context, groupName, resource, action string) (bool, error) {
+	var count int
+	err := r.db.QueryRowContext(ctx, `SELECT COUNT(1)
+        FROM group_permissions gp
+        JOIN groups g ON g.id = gp.group_id
+        JOIN permissions p ON p.id = gp.permission_id
+        WHERE g.name=$1 AND p.resource=$2 AND p.action=$3`, groupName, resource, action).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}

--- a/internal/domains/portal/repositories/impl/permission_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/permission_repository_pg.go
@@ -65,6 +65,18 @@ func (r *pgPermissionRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	return err
 }
 
+func (r *pgPermissionRepo) GetByResourceAction(ctx context.Context, resource, action string) (*entities.Permission, error) {
+	row := r.db.QueryRowContext(ctx, `SELECT id, resource, action, description FROM permissions WHERE resource=$1 AND action=$2`, resource, action)
+	var p entities.Permission
+	if err := row.Scan(&p.ID, &p.Resource, &p.Action, &p.Description); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &p, nil
+}
+
 func (r *pgPermissionRepo) GetByGroup(ctx context.Context, groupID uuid.UUID) ([]*entities.Permission, error) {
 	rows, err := r.db.QueryContext(ctx, `SELECT p.id, p.resource, p.action, p.description
         FROM permissions p

--- a/internal/domains/portal/repositories/impl/user_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/user_repository_pg.go
@@ -63,6 +63,22 @@ func (r *pgUserRepo) GetByUsername(ctx context.Context, username string) (*entit
 	return &u, nil
 }
 
+func (r *pgUserRepo) GetByEmail(ctx context.Context, email string) (*entities.PortalUser, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT id, username, email, password_hash, full_name, group_id, is_active, created_at, updated_at
+        FROM users WHERE email=$1`, email)
+	var u entities.PortalUser
+	err := row.Scan(&u.ID, &u.Username, &u.Email, &u.Password, &u.FullName, &u.GroupID, &u.IsActive, &u.CreatedAt, &u.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		logger.Log.WithError(err).Error("get user by email failed")
+		return nil, err
+	}
+	return &u, nil
+}
+
 func (r *pgUserRepo) List(ctx context.Context) ([]*entities.PortalUser, error) {
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT id, username, email, full_name, group_id, is_active, created_at, updated_at FROM users`)

--- a/internal/domains/portal/repositories/impl/user_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/user_repository_pg.go
@@ -100,8 +100,8 @@ func (r *pgUserRepo) List(ctx context.Context) ([]*entities.PortalUser, error) {
 func (r *pgUserRepo) Update(ctx context.Context, u *entities.PortalUser) error {
 	u.UpdatedAt = time.Now()
 	_, err := r.db.ExecContext(ctx,
-		`UPDATE users SET username=$2, email=$3, password_hash=$4, full_name=$5, group_id=$6, is_active=$7, updated_at=$8 WHERE id=$1`,
-		u.ID, u.Username, u.Email, u.Password, u.FullName, u.GroupID, u.IsActive, u.UpdatedAt,
+		`UPDATE users SET password_hash=$2, full_name=$3, group_id=$4, is_active=$5, updated_at=$6 WHERE id=$1`,
+		u.ID, u.Password, u.FullName, u.GroupID, u.IsActive, u.UpdatedAt,
 	)
 	if err != nil {
 		logger.Log.WithError(err).Error("update user failed")

--- a/internal/domains/portal/repositories/ldap_config_repository.go
+++ b/internal/domains/portal/repositories/ldap_config_repository.go
@@ -9,4 +9,5 @@ type LDAPConfigRepository interface {
 	Get(ctx context.Context) (*entities.LDAPConfig, error)
 	Create(ctx context.Context, cfg *entities.LDAPConfig) error
 	Update(ctx context.Context, cfg *entities.LDAPConfig) error
+	Delete(ctx context.Context) error
 }

--- a/internal/domains/portal/repositories/ldap_config_repository.go
+++ b/internal/domains/portal/repositories/ldap_config_repository.go
@@ -1,0 +1,12 @@
+package repositories
+
+import (
+	"context"
+	"system-portal/internal/domains/portal/entities"
+)
+
+type LDAPConfigRepository interface {
+	Get(ctx context.Context) (*entities.LDAPConfig, error)
+	Create(ctx context.Context, cfg *entities.LDAPConfig) error
+	Update(ctx context.Context, cfg *entities.LDAPConfig) error
+}

--- a/internal/domains/portal/repositories/openvpn_config_repository.go
+++ b/internal/domains/portal/repositories/openvpn_config_repository.go
@@ -9,4 +9,5 @@ type OpenVPNConfigRepository interface {
 	Get(ctx context.Context) (*entities.OpenVPNConfig, error)
 	Create(ctx context.Context, cfg *entities.OpenVPNConfig) error
 	Update(ctx context.Context, cfg *entities.OpenVPNConfig) error
+	Delete(ctx context.Context) error
 }

--- a/internal/domains/portal/repositories/openvpn_config_repository.go
+++ b/internal/domains/portal/repositories/openvpn_config_repository.go
@@ -1,0 +1,12 @@
+package repositories
+
+import (
+	"context"
+	"system-portal/internal/domains/portal/entities"
+)
+
+type OpenVPNConfigRepository interface {
+	Get(ctx context.Context) (*entities.OpenVPNConfig, error)
+	Create(ctx context.Context, cfg *entities.OpenVPNConfig) error
+	Update(ctx context.Context, cfg *entities.OpenVPNConfig) error
+}

--- a/internal/domains/portal/repositories/permission_repository.go
+++ b/internal/domains/portal/repositories/permission_repository.go
@@ -1,0 +1,15 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"system-portal/internal/domains/portal/entities"
+)
+
+type PermissionRepository interface {
+	List(ctx context.Context) ([]*entities.Permission, error)
+	GetByGroup(ctx context.Context, groupID uuid.UUID) ([]*entities.Permission, error)
+	SetForGroup(ctx context.Context, groupID uuid.UUID, permIDs []uuid.UUID) error
+	HasGroupPermission(ctx context.Context, groupName, resource, action string) (bool, error)
+}

--- a/internal/domains/portal/repositories/permission_repository.go
+++ b/internal/domains/portal/repositories/permission_repository.go
@@ -9,6 +9,10 @@ import (
 
 type PermissionRepository interface {
 	List(ctx context.Context) ([]*entities.Permission, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*entities.Permission, error)
+	Create(ctx context.Context, p *entities.Permission) error
+	Update(ctx context.Context, p *entities.Permission) error
+	Delete(ctx context.Context, id uuid.UUID) error
 	GetByGroup(ctx context.Context, groupID uuid.UUID) ([]*entities.Permission, error)
 	SetForGroup(ctx context.Context, groupID uuid.UUID, permIDs []uuid.UUID) error
 	HasGroupPermission(ctx context.Context, groupName, resource, action string) (bool, error)

--- a/internal/domains/portal/repositories/permission_repository.go
+++ b/internal/domains/portal/repositories/permission_repository.go
@@ -13,6 +13,7 @@ type PermissionRepository interface {
 	Create(ctx context.Context, p *entities.Permission) error
 	Update(ctx context.Context, p *entities.Permission) error
 	Delete(ctx context.Context, id uuid.UUID) error
+	GetByResourceAction(ctx context.Context, resource, action string) (*entities.Permission, error)
 	GetByGroup(ctx context.Context, groupID uuid.UUID) ([]*entities.Permission, error)
 	SetForGroup(ctx context.Context, groupID uuid.UUID, permIDs []uuid.UUID) error
 	HasGroupPermission(ctx context.Context, groupName, resource, action string) (bool, error)

--- a/internal/domains/portal/repositories/user_repository.go
+++ b/internal/domains/portal/repositories/user_repository.go
@@ -12,6 +12,7 @@ type UserRepository interface {
 	Create(ctx context.Context, user *entities.PortalUser) error
 	GetByID(ctx context.Context, id uuid.UUID) (*entities.PortalUser, error)
 	GetByUsername(ctx context.Context, username string) (*entities.PortalUser, error)
+	GetByEmail(ctx context.Context, email string) (*entities.PortalUser, error)
 	List(ctx context.Context) ([]*entities.PortalUser, error)
 	Update(ctx context.Context, user *entities.PortalUser) error
 	Delete(ctx context.Context, id uuid.UUID) error

--- a/internal/domains/portal/repositories/user_repository.go
+++ b/internal/domains/portal/repositories/user_repository.go
@@ -13,7 +13,7 @@ type UserRepository interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*entities.PortalUser, error)
 	GetByUsername(ctx context.Context, username string) (*entities.PortalUser, error)
 	GetByEmail(ctx context.Context, email string) (*entities.PortalUser, error)
-	List(ctx context.Context) ([]*entities.PortalUser, error)
+       List(ctx context.Context, filter *entities.UserFilter) ([]*entities.PortalUser, int, error)
 	Update(ctx context.Context, user *entities.PortalUser) error
 	Delete(ctx context.Context, id uuid.UUID) error
 }

--- a/internal/domains/portal/routes/portal_routes.go
+++ b/internal/domains/portal/routes/portal_routes.go
@@ -122,7 +122,9 @@ func registerConfigRoutes(portal *gin.RouterGroup) {
 	{
 		conn.POST("/openvpn", configHandler.CreateOpenVPNConfig)
 		conn.PUT("/openvpn", configHandler.UpdateOpenVPNConfig)
+		conn.DELETE("/openvpn", configHandler.DeleteOpenVPNConfig)
 		conn.POST("/ldap", configHandler.CreateLDAPConfig)
 		conn.PUT("/ldap", configHandler.UpdateLDAPConfig)
+		conn.DELETE("/ldap", configHandler.DeleteLDAPConfig)
 	}
 }

--- a/internal/domains/portal/routes/portal_routes.go
+++ b/internal/domains/portal/routes/portal_routes.go
@@ -120,9 +120,11 @@ func registerDashboardRoutes(portal *gin.RouterGroup) {
 func registerConfigRoutes(portal *gin.RouterGroup) {
 	conn := portal.Group("/connections")
 	{
+		conn.GET("/openvpn", configHandler.GetOpenVPNConfig)
 		conn.POST("/openvpn", configHandler.CreateOpenVPNConfig)
 		conn.PUT("/openvpn", configHandler.UpdateOpenVPNConfig)
 		conn.DELETE("/openvpn", configHandler.DeleteOpenVPNConfig)
+		conn.GET("/ldap", configHandler.GetLDAPConfig)
 		conn.POST("/ldap", configHandler.CreateLDAPConfig)
 		conn.PUT("/ldap", configHandler.UpdateLDAPConfig)
 		conn.DELETE("/ldap", configHandler.DeleteLDAPConfig)

--- a/internal/domains/portal/routes/portal_routes.go
+++ b/internal/domains/portal/routes/portal_routes.go
@@ -15,6 +15,7 @@ var (
 	permissionHandler *portalHandlers.PermissionHandler
 	auditHandler      *portalHandlers.AuditHandler
 	dashboardHandler  *portalHandlers.DashboardHandler
+	configHandler     *portalHandlers.ConfigHandler
 )
 
 // Initialize sets up the handler dependencies
@@ -24,12 +25,14 @@ func Initialize(
 	ph *portalHandlers.PermissionHandler,
 	ah *portalHandlers.AuditHandler,
 	dh *portalHandlers.DashboardHandler,
+	ch *portalHandlers.ConfigHandler,
 ) {
 	userHandler = uh
 	groupHandler = gh
 	permissionHandler = ph
 	auditHandler = ah
 	dashboardHandler = dh
+	configHandler = ch
 }
 
 // RegisterRoutes registers all portal routes
@@ -45,6 +48,9 @@ func RegisterRoutes(router *gin.RouterGroup) {
 
 	// Portal group management routes
 	registerGroupRoutes(portal)
+
+	// Connection config routes
+	registerConfigRoutes(portal)
 
 	// Audit log routes
 	registerAuditRoutes(portal)
@@ -108,5 +114,15 @@ func registerDashboardRoutes(portal *gin.RouterGroup) {
 		dashboard.GET("/activities", dashboardHandler.GetRecentActivities)
 		dashboard.GET("/charts/users", dashboardHandler.GetUserChartData)
 		dashboard.GET("/charts/activities", dashboardHandler.GetActivityChartData)
+	}
+}
+
+func registerConfigRoutes(portal *gin.RouterGroup) {
+	conn := portal.Group("/connections")
+	{
+		conn.POST("/openvpn", configHandler.CreateOpenVPNConfig)
+		conn.PUT("/openvpn", configHandler.UpdateOpenVPNConfig)
+		conn.POST("/ldap", configHandler.CreateLDAPConfig)
+		conn.PUT("/ldap", configHandler.UpdateLDAPConfig)
 	}
 }

--- a/internal/domains/portal/routes/portal_routes.go
+++ b/internal/domains/portal/routes/portal_routes.go
@@ -124,9 +124,11 @@ func registerConfigRoutes(portal *gin.RouterGroup) {
 		conn.POST("/openvpn", configHandler.CreateOpenVPNConfig)
 		conn.PUT("/openvpn", configHandler.UpdateOpenVPNConfig)
 		conn.DELETE("/openvpn", configHandler.DeleteOpenVPNConfig)
+		conn.POST("/openvpn/test", configHandler.TestOpenVPN)
 		conn.GET("/ldap", configHandler.GetLDAPConfig)
 		conn.POST("/ldap", configHandler.CreateLDAPConfig)
 		conn.PUT("/ldap", configHandler.UpdateLDAPConfig)
 		conn.DELETE("/ldap", configHandler.DeleteLDAPConfig)
+		conn.POST("/ldap/test", configHandler.TestLDAP)
 	}
 }

--- a/internal/domains/portal/routes/portal_routes.go
+++ b/internal/domains/portal/routes/portal_routes.go
@@ -10,21 +10,24 @@ import (
 
 // Dependencies injected from main
 var (
-	userHandler      *handlers.UserHandler
-	groupHandler     *handlers.GroupHandler
-	auditHandler     *handlers.AuditHandler
-	dashboardHandler *handlers.DashboardHandler
+	userHandler       *handlers.UserHandler
+	groupHandler      *handlers.GroupHandler
+	permissionHandler *handlers.PermissionHandler
+	auditHandler      *handlers.AuditHandler
+	dashboardHandler  *handlers.DashboardHandler
 )
 
 // Initialize sets up the handler dependencies
 func Initialize(
 	uh *handlers.UserHandler,
 	gh *handlers.GroupHandler,
+	ph *handlers.PermissionHandler,
 	ah *handlers.AuditHandler,
 	dh *handlers.DashboardHandler,
 ) {
 	userHandler = uh
 	groupHandler = gh
+	permissionHandler = ph
 	auditHandler = ah
 	dashboardHandler = dh
 }
@@ -38,7 +41,7 @@ func RegisterRoutes(router *gin.RouterGroup) {
 
 	// Portal user management routes
 	registerUserRoutes(portal)
-	portal.GET("/permissions", groupHandler.ListPermissions)
+	registerPermissionRoutes(portal)
 
 	// Portal group management routes
 	registerGroupRoutes(portal)
@@ -74,6 +77,16 @@ func registerGroupRoutes(portal *gin.RouterGroup) {
 		groups.GET("/:id/permissions", groupHandler.GetGroupPermissions)
 		groups.PUT("/:id/permissions", groupHandler.UpdateGroupPermissions)
 		// Groups are predefined (admin, support), so no create/update/delete
+	}
+}
+
+func registerPermissionRoutes(portal *gin.RouterGroup) {
+	perms := portal.Group("/permissions")
+	{
+		perms.GET("", permissionHandler.ListPermissions)
+		perms.POST("", permissionHandler.CreatePermission)
+		perms.PUT("/:id", permissionHandler.UpdatePermission)
+		perms.DELETE("/:id", permissionHandler.DeletePermission)
 	}
 }
 

--- a/internal/domains/portal/routes/portal_routes.go
+++ b/internal/domains/portal/routes/portal_routes.go
@@ -38,6 +38,7 @@ func RegisterRoutes(router *gin.RouterGroup) {
 
 	// Portal user management routes
 	registerUserRoutes(portal)
+	portal.GET("/permissions", groupHandler.ListPermissions)
 
 	// Portal group management routes
 	registerGroupRoutes(portal)
@@ -70,6 +71,8 @@ func registerGroupRoutes(portal *gin.RouterGroup) {
 	{
 		groups.GET("", groupHandler.ListGroups)
 		groups.GET("/:id", groupHandler.GetGroup)
+		groups.GET("/:id/permissions", groupHandler.GetGroupPermissions)
+		groups.PUT("/:id/permissions", groupHandler.UpdateGroupPermissions)
 		// Groups are predefined (admin, support), so no create/update/delete
 	}
 }

--- a/internal/domains/portal/routes/portal_routes.go
+++ b/internal/domains/portal/routes/portal_routes.go
@@ -2,28 +2,28 @@
 package routes
 
 import (
-        portalHandlers "system-portal/internal/domains/portal/handlers"
-        "system-portal/internal/shared/middleware"
+	portalHandlers "system-portal/internal/domains/portal/handlers"
+	"system-portal/internal/shared/middleware"
 
-        "github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin"
 )
 
 // Dependencies injected from main
 var (
-        userHandler       *portalHandlers.UserHandler
-        groupHandler      *portalHandlers.GroupHandler
-        permissionHandler *portalHandlers.PermissionHandler
-        auditHandler      *portalHandlers.AuditHandler
-        dashboardHandler  *portalHandlers.DashboardHandler
+	userHandler       *portalHandlers.UserHandler
+	groupHandler      *portalHandlers.GroupHandler
+	permissionHandler *portalHandlers.PermissionHandler
+	auditHandler      *portalHandlers.AuditHandler
+	dashboardHandler  *portalHandlers.DashboardHandler
 )
 
 // Initialize sets up the handler dependencies
 func Initialize(
-        uh *portalHandlers.UserHandler,
-        gh *portalHandlers.GroupHandler,
-        ph *portalHandlers.PermissionHandler,
-        ah *portalHandlers.AuditHandler,
-        dh *portalHandlers.DashboardHandler,
+	uh *portalHandlers.UserHandler,
+	gh *portalHandlers.GroupHandler,
+	ph *portalHandlers.PermissionHandler,
+	ah *portalHandlers.AuditHandler,
+	dh *portalHandlers.DashboardHandler,
 ) {
 	userHandler = uh
 	groupHandler = gh
@@ -74,9 +74,11 @@ func registerGroupRoutes(portal *gin.RouterGroup) {
 	{
 		groups.GET("", groupHandler.ListGroups)
 		groups.GET("/:id", groupHandler.GetGroup)
+		groups.POST("", groupHandler.CreateGroup)
+		groups.PUT("/:id", groupHandler.UpdateGroup)
+		groups.DELETE("/:id", groupHandler.DeleteGroup)
 		groups.GET("/:id/permissions", groupHandler.GetGroupPermissions)
 		groups.PUT("/:id/permissions", groupHandler.UpdateGroupPermissions)
-		// Groups are predefined (admin, support), so no create/update/delete
 	}
 }
 

--- a/internal/domains/portal/routes/portal_routes.go
+++ b/internal/domains/portal/routes/portal_routes.go
@@ -2,28 +2,28 @@
 package routes
 
 import (
-	"system-portal/internal/domains/portal/handlers"
-	"system-portal/internal/shared/middleware"
+        portalHandlers "system-portal/internal/domains/portal/handlers"
+        "system-portal/internal/shared/middleware"
 
-	"github.com/gin-gonic/gin"
+        "github.com/gin-gonic/gin"
 )
 
 // Dependencies injected from main
 var (
-	userHandler       *handlers.UserHandler
-	groupHandler      *handlers.GroupHandler
-	permissionHandler *handlers.PermissionHandler
-	auditHandler      *handlers.AuditHandler
-	dashboardHandler  *handlers.DashboardHandler
+        userHandler       *portalHandlers.UserHandler
+        groupHandler      *portalHandlers.GroupHandler
+        permissionHandler *portalHandlers.PermissionHandler
+        auditHandler      *portalHandlers.AuditHandler
+        dashboardHandler  *portalHandlers.DashboardHandler
 )
 
 // Initialize sets up the handler dependencies
 func Initialize(
-	uh *handlers.UserHandler,
-	gh *handlers.GroupHandler,
-	ph *handlers.PermissionHandler,
-	ah *handlers.AuditHandler,
-	dh *handlers.DashboardHandler,
+        uh *portalHandlers.UserHandler,
+        gh *portalHandlers.GroupHandler,
+        ph *portalHandlers.PermissionHandler,
+        ah *portalHandlers.AuditHandler,
+        dh *portalHandlers.DashboardHandler,
 ) {
 	userHandler = uh
 	groupHandler = gh

--- a/internal/domains/portal/usecases/audit_usecase.go
+++ b/internal/domains/portal/usecases/audit_usecase.go
@@ -8,6 +8,6 @@ import (
 
 type AuditUsecase interface {
 	Add(ctx context.Context, log *entities.AuditLog) error
-	List(ctx context.Context) ([]*entities.AuditLog, error)
+	List(ctx context.Context, filter *entities.AuditFilter) ([]*entities.AuditLog, int, error)
 	Get(ctx context.Context, id uuid.UUID) (*entities.AuditLog, error)
 }

--- a/internal/domains/portal/usecases/audit_usecase_impl.go
+++ b/internal/domains/portal/usecases/audit_usecase_impl.go
@@ -18,8 +18,8 @@ func (a *auditUsecaseImpl) Add(ctx context.Context, l *entities.AuditLog) error 
 	return a.repo.Add(ctx, l)
 }
 
-func (a *auditUsecaseImpl) List(ctx context.Context) ([]*entities.AuditLog, error) {
-	return a.repo.List(ctx)
+func (a *auditUsecaseImpl) List(ctx context.Context, f *entities.AuditFilter) ([]*entities.AuditLog, int, error) {
+	return a.repo.List(ctx, f)
 }
 
 func (a *auditUsecaseImpl) Get(ctx context.Context, id uuid.UUID) (*entities.AuditLog, error) {

--- a/internal/domains/portal/usecases/config_usecase.go
+++ b/internal/domains/portal/usecases/config_usecase.go
@@ -8,6 +8,8 @@ import (
 type ConfigUsecase interface {
 	GetOpenVPN(ctx context.Context) (*entities.OpenVPNConfig, error)
 	SetOpenVPN(ctx context.Context, cfg *entities.OpenVPNConfig) error
+	DeleteOpenVPN(ctx context.Context) error
 	GetLDAP(ctx context.Context) (*entities.LDAPConfig, error)
 	SetLDAP(ctx context.Context, cfg *entities.LDAPConfig) error
+	DeleteLDAP(ctx context.Context) error
 }

--- a/internal/domains/portal/usecases/config_usecase.go
+++ b/internal/domains/portal/usecases/config_usecase.go
@@ -9,7 +9,9 @@ type ConfigUsecase interface {
 	GetOpenVPN(ctx context.Context) (*entities.OpenVPNConfig, error)
 	SetOpenVPN(ctx context.Context, cfg *entities.OpenVPNConfig) error
 	DeleteOpenVPN(ctx context.Context) error
+	TestOpenVPN(ctx context.Context, cfg *entities.OpenVPNConfig) error
 	GetLDAP(ctx context.Context) (*entities.LDAPConfig, error)
 	SetLDAP(ctx context.Context, cfg *entities.LDAPConfig) error
 	DeleteLDAP(ctx context.Context) error
+	TestLDAP(ctx context.Context, cfg *entities.LDAPConfig) error
 }

--- a/internal/domains/portal/usecases/config_usecase.go
+++ b/internal/domains/portal/usecases/config_usecase.go
@@ -1,0 +1,13 @@
+package usecases
+
+import (
+	"context"
+	"system-portal/internal/domains/portal/entities"
+)
+
+type ConfigUsecase interface {
+	GetOpenVPN(ctx context.Context) (*entities.OpenVPNConfig, error)
+	SetOpenVPN(ctx context.Context, cfg *entities.OpenVPNConfig) error
+	GetLDAP(ctx context.Context) (*entities.LDAPConfig, error)
+	SetLDAP(ctx context.Context, cfg *entities.LDAPConfig) error
+}

--- a/internal/domains/portal/usecases/config_usecase_impl.go
+++ b/internal/domains/portal/usecases/config_usecase_impl.go
@@ -1,0 +1,79 @@
+package usecases
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"system-portal/internal/domains/portal/entities"
+	"system-portal/internal/domains/portal/repositories"
+)
+
+type configUsecaseImpl struct {
+	ovRepo   repositories.OpenVPNConfigRepository
+	ldapRepo repositories.LDAPConfigRepository
+}
+
+func NewConfigUsecase(ov repositories.OpenVPNConfigRepository, ldap repositories.LDAPConfigRepository) ConfigUsecase {
+	return &configUsecaseImpl{ovRepo: ov, ldapRepo: ldap}
+}
+
+func (u *configUsecaseImpl) GetOpenVPN(ctx context.Context) (*entities.OpenVPNConfig, error) {
+	if u.ovRepo == nil {
+		return nil, nil
+	}
+	return u.ovRepo.Get(ctx)
+}
+
+func (u *configUsecaseImpl) SetOpenVPN(ctx context.Context, cfg *entities.OpenVPNConfig) error {
+	if u.ovRepo == nil {
+		return nil
+	}
+	existing, err := u.ovRepo.Get(ctx)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	if existing == nil {
+		if cfg.ID == uuid.Nil {
+			cfg.ID = uuid.New()
+		}
+		cfg.CreatedAt = now
+		cfg.UpdatedAt = now
+		return u.ovRepo.Create(ctx, cfg)
+	}
+	cfg.ID = existing.ID
+	cfg.CreatedAt = existing.CreatedAt
+	cfg.UpdatedAt = now
+	return u.ovRepo.Update(ctx, cfg)
+}
+
+func (u *configUsecaseImpl) GetLDAP(ctx context.Context) (*entities.LDAPConfig, error) {
+	if u.ldapRepo == nil {
+		return nil, nil
+	}
+	return u.ldapRepo.Get(ctx)
+}
+
+func (u *configUsecaseImpl) SetLDAP(ctx context.Context, cfg *entities.LDAPConfig) error {
+	if u.ldapRepo == nil {
+		return nil
+	}
+	existing, err := u.ldapRepo.Get(ctx)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	if existing == nil {
+		if cfg.ID == uuid.Nil {
+			cfg.ID = uuid.New()
+		}
+		cfg.CreatedAt = now
+		cfg.UpdatedAt = now
+		return u.ldapRepo.Create(ctx, cfg)
+	}
+	cfg.ID = existing.ID
+	cfg.CreatedAt = existing.CreatedAt
+	cfg.UpdatedAt = now
+	return u.ldapRepo.Update(ctx, cfg)
+}

--- a/internal/domains/portal/usecases/config_usecase_impl.go
+++ b/internal/domains/portal/usecases/config_usecase_impl.go
@@ -48,6 +48,13 @@ func (u *configUsecaseImpl) SetOpenVPN(ctx context.Context, cfg *entities.OpenVP
 	return u.ovRepo.Update(ctx, cfg)
 }
 
+func (u *configUsecaseImpl) DeleteOpenVPN(ctx context.Context) error {
+	if u.ovRepo == nil {
+		return nil
+	}
+	return u.ovRepo.Delete(ctx)
+}
+
 func (u *configUsecaseImpl) GetLDAP(ctx context.Context) (*entities.LDAPConfig, error) {
 	if u.ldapRepo == nil {
 		return nil, nil
@@ -76,4 +83,11 @@ func (u *configUsecaseImpl) SetLDAP(ctx context.Context, cfg *entities.LDAPConfi
 	cfg.CreatedAt = existing.CreatedAt
 	cfg.UpdatedAt = now
 	return u.ldapRepo.Update(ctx, cfg)
+}
+
+func (u *configUsecaseImpl) DeleteLDAP(ctx context.Context) error {
+	if u.ldapRepo == nil {
+		return nil
+	}
+	return u.ldapRepo.Delete(ctx)
 }

--- a/internal/domains/portal/usecases/config_usecase_impl.go
+++ b/internal/domains/portal/usecases/config_usecase_impl.go
@@ -7,6 +7,8 @@ import (
 	"github.com/google/uuid"
 	"system-portal/internal/domains/portal/entities"
 	"system-portal/internal/domains/portal/repositories"
+	"system-portal/internal/shared/infrastructure/ldap"
+	"system-portal/internal/shared/infrastructure/xmlrpc"
 )
 
 type configUsecaseImpl struct {
@@ -55,6 +57,11 @@ func (u *configUsecaseImpl) DeleteOpenVPN(ctx context.Context) error {
 	return u.ovRepo.Delete(ctx)
 }
 
+func (u *configUsecaseImpl) TestOpenVPN(ctx context.Context, cfg *entities.OpenVPNConfig) error {
+	client := xmlrpc.NewClient(xmlrpc.Config{Host: cfg.Host, Username: cfg.Username, Password: cfg.Password, Port: cfg.Port})
+	return client.Ping()
+}
+
 func (u *configUsecaseImpl) GetLDAP(ctx context.Context) (*entities.LDAPConfig, error) {
 	if u.ldapRepo == nil {
 		return nil, nil
@@ -90,4 +97,14 @@ func (u *configUsecaseImpl) DeleteLDAP(ctx context.Context) error {
 		return nil
 	}
 	return u.ldapRepo.Delete(ctx)
+}
+
+func (u *configUsecaseImpl) TestLDAP(ctx context.Context, cfg *entities.LDAPConfig) error {
+	client := ldap.NewClient(ldap.Config{Host: cfg.Host, Port: cfg.Port, BindDN: cfg.BindDN, BindPassword: cfg.BindPassword, BaseDN: cfg.BaseDN})
+	conn, err := client.Connect()
+	if err != nil {
+		return err
+	}
+	conn.Close()
+	return nil
 }

--- a/internal/domains/portal/usecases/group_usecase.go
+++ b/internal/domains/portal/usecases/group_usecase.go
@@ -10,4 +10,8 @@ type GroupUsecase interface {
 	Create(ctx context.Context, g *entities.PortalGroup) error
 	List(ctx context.Context) ([]*entities.PortalGroup, error)
 	Get(ctx context.Context, id uuid.UUID) (*entities.PortalGroup, error)
+	GetByName(ctx context.Context, name string) (*entities.PortalGroup, error)
+	UpdatePermissions(ctx context.Context, id uuid.UUID, permIDs []uuid.UUID) error
+	GetPermissions(ctx context.Context, id uuid.UUID) ([]*entities.Permission, error)
+	ListPermissions(ctx context.Context) ([]*entities.Permission, error)
 }

--- a/internal/domains/portal/usecases/group_usecase.go
+++ b/internal/domains/portal/usecases/group_usecase.go
@@ -11,6 +11,8 @@ type GroupUsecase interface {
 	List(ctx context.Context) ([]*entities.PortalGroup, error)
 	Get(ctx context.Context, id uuid.UUID) (*entities.PortalGroup, error)
 	GetByName(ctx context.Context, name string) (*entities.PortalGroup, error)
+	Update(ctx context.Context, g *entities.PortalGroup) error
+	Delete(ctx context.Context, id uuid.UUID) error
 	UpdatePermissions(ctx context.Context, id uuid.UUID, permIDs []uuid.UUID) error
 	GetPermissions(ctx context.Context, id uuid.UUID) ([]*entities.Permission, error)
 	ListPermissions(ctx context.Context) ([]*entities.Permission, error)

--- a/internal/domains/portal/usecases/group_usecase.go
+++ b/internal/domains/portal/usecases/group_usecase.go
@@ -8,7 +8,7 @@ import (
 
 type GroupUsecase interface {
 	Create(ctx context.Context, g *entities.PortalGroup) error
-	List(ctx context.Context) ([]*entities.PortalGroup, error)
+	List(ctx context.Context, filter *entities.GroupFilter) ([]*entities.PortalGroup, int, error)
 	Get(ctx context.Context, id uuid.UUID) (*entities.PortalGroup, error)
 	GetByName(ctx context.Context, name string) (*entities.PortalGroup, error)
 	Update(ctx context.Context, g *entities.PortalGroup) error

--- a/internal/domains/portal/usecases/group_usecase_impl.go
+++ b/internal/domains/portal/usecases/group_usecase_impl.go
@@ -8,10 +8,13 @@ import (
 	"system-portal/internal/domains/portal/repositories"
 )
 
-type groupUsecaseImpl struct{ repo repositories.GroupRepository }
+type groupUsecaseImpl struct {
+	repo     repositories.GroupRepository
+	permRepo repositories.PermissionRepository
+}
 
-func NewGroupUsecase(repo repositories.GroupRepository) GroupUsecase {
-	return &groupUsecaseImpl{repo: repo}
+func NewGroupUsecase(repo repositories.GroupRepository, perm repositories.PermissionRepository) GroupUsecase {
+	return &groupUsecaseImpl{repo: repo, permRepo: perm}
 }
 
 func (g *groupUsecaseImpl) Create(ctx context.Context, gr *entities.PortalGroup) error {
@@ -24,4 +27,29 @@ func (g *groupUsecaseImpl) List(ctx context.Context) ([]*entities.PortalGroup, e
 
 func (g *groupUsecaseImpl) Get(ctx context.Context, id uuid.UUID) (*entities.PortalGroup, error) {
 	return g.repo.GetByID(ctx, id)
+}
+
+func (g *groupUsecaseImpl) GetByName(ctx context.Context, name string) (*entities.PortalGroup, error) {
+	return g.repo.GetByName(ctx, name)
+}
+
+func (g *groupUsecaseImpl) UpdatePermissions(ctx context.Context, id uuid.UUID, permIDs []uuid.UUID) error {
+	if g.permRepo == nil {
+		return nil
+	}
+	return g.permRepo.SetForGroup(ctx, id, permIDs)
+}
+
+func (g *groupUsecaseImpl) GetPermissions(ctx context.Context, id uuid.UUID) ([]*entities.Permission, error) {
+	if g.permRepo == nil {
+		return nil, nil
+	}
+	return g.permRepo.GetByGroup(ctx, id)
+}
+
+func (g *groupUsecaseImpl) ListPermissions(ctx context.Context) ([]*entities.Permission, error) {
+	if g.permRepo == nil {
+		return nil, nil
+	}
+	return g.permRepo.List(ctx)
 }

--- a/internal/domains/portal/usecases/group_usecase_impl.go
+++ b/internal/domains/portal/usecases/group_usecase_impl.go
@@ -30,10 +30,10 @@ func (g *groupUsecaseImpl) Create(ctx context.Context, gr *entities.PortalGroup)
 	return g.repo.Create(ctx, gr)
 }
 
-func (g *groupUsecaseImpl) List(ctx context.Context) ([]*entities.PortalGroup, error) {
-	groups, err := g.repo.List(ctx)
+func (g *groupUsecaseImpl) List(ctx context.Context, filter *entities.GroupFilter) ([]*entities.PortalGroup, int, error) {
+	groups, total, err := g.repo.List(ctx, filter)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if g.permRepo != nil {
 		for _, grp := range groups {
@@ -41,7 +41,7 @@ func (g *groupUsecaseImpl) List(ctx context.Context) ([]*entities.PortalGroup, e
 			grp.Permissions = perms
 		}
 	}
-	return groups, nil
+	return groups, total, nil
 }
 
 func (g *groupUsecaseImpl) Get(ctx context.Context, id uuid.UUID) (*entities.PortalGroup, error) {

--- a/internal/domains/portal/usecases/group_usecase_impl.go
+++ b/internal/domains/portal/usecases/group_usecase_impl.go
@@ -89,6 +89,22 @@ func (g *groupUsecaseImpl) UpdatePermissions(ctx context.Context, id uuid.UUID, 
 	if g.permRepo == nil {
 		return nil
 	}
+	grp, err := g.repo.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if grp == nil {
+		return fmt.Errorf("group not found")
+	}
+	for _, pid := range permIDs {
+		p, err := g.permRepo.GetByID(ctx, pid)
+		if err != nil {
+			return err
+		}
+		if p == nil {
+			return fmt.Errorf("permission not found")
+		}
+	}
 	return g.permRepo.SetForGroup(ctx, id, permIDs)
 }
 

--- a/internal/domains/portal/usecases/permission_usecase.go
+++ b/internal/domains/portal/usecases/permission_usecase.go
@@ -1,0 +1,15 @@
+package usecases
+
+import (
+	"context"
+	"github.com/google/uuid"
+	"system-portal/internal/domains/portal/entities"
+)
+
+type PermissionUsecase interface {
+	List(ctx context.Context) ([]*entities.Permission, error)
+	Get(ctx context.Context, id uuid.UUID) (*entities.Permission, error)
+	Create(ctx context.Context, p *entities.Permission) error
+	Update(ctx context.Context, p *entities.Permission) error
+	Delete(ctx context.Context, id uuid.UUID) error
+}

--- a/internal/domains/portal/usecases/permission_usecase_impl.go
+++ b/internal/domains/portal/usecases/permission_usecase_impl.go
@@ -2,6 +2,8 @@ package usecases
 
 import (
 	"context"
+	"fmt"
+
 	"github.com/google/uuid"
 	"system-portal/internal/domains/portal/entities"
 	"system-portal/internal/domains/portal/repositories"
@@ -24,10 +26,27 @@ func (u *permissionUsecaseImpl) Get(ctx context.Context, id uuid.UUID) (*entitie
 }
 
 func (u *permissionUsecaseImpl) Create(ctx context.Context, p *entities.Permission) error {
+	if existing, err := u.repo.GetByResourceAction(ctx, p.Resource, p.Action); err == nil && existing != nil {
+		return fmt.Errorf("permission already exists")
+	} else if err != nil {
+		return err
+	}
 	return u.repo.Create(ctx, p)
 }
 
 func (u *permissionUsecaseImpl) Update(ctx context.Context, p *entities.Permission) error {
+	existing, err := u.repo.GetByID(ctx, p.ID)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return fmt.Errorf("permission not found")
+	}
+	if dup, err := u.repo.GetByResourceAction(ctx, p.Resource, p.Action); err == nil && dup != nil && dup.ID != p.ID {
+		return fmt.Errorf("permission already exists")
+	} else if err != nil {
+		return err
+	}
 	return u.repo.Update(ctx, p)
 }
 

--- a/internal/domains/portal/usecases/permission_usecase_impl.go
+++ b/internal/domains/portal/usecases/permission_usecase_impl.go
@@ -1,0 +1,36 @@
+package usecases
+
+import (
+	"context"
+	"github.com/google/uuid"
+	"system-portal/internal/domains/portal/entities"
+	"system-portal/internal/domains/portal/repositories"
+)
+
+type permissionUsecaseImpl struct {
+	repo repositories.PermissionRepository
+}
+
+func NewPermissionUsecase(r repositories.PermissionRepository) PermissionUsecase {
+	return &permissionUsecaseImpl{repo: r}
+}
+
+func (u *permissionUsecaseImpl) List(ctx context.Context) ([]*entities.Permission, error) {
+	return u.repo.List(ctx)
+}
+
+func (u *permissionUsecaseImpl) Get(ctx context.Context, id uuid.UUID) (*entities.Permission, error) {
+	return u.repo.GetByID(ctx, id)
+}
+
+func (u *permissionUsecaseImpl) Create(ctx context.Context, p *entities.Permission) error {
+	return u.repo.Create(ctx, p)
+}
+
+func (u *permissionUsecaseImpl) Update(ctx context.Context, p *entities.Permission) error {
+	return u.repo.Update(ctx, p)
+}
+
+func (u *permissionUsecaseImpl) Delete(ctx context.Context, id uuid.UUID) error {
+	return u.repo.Delete(ctx, id)
+}

--- a/internal/domains/portal/usecases/user_usecase.go
+++ b/internal/domains/portal/usecases/user_usecase.go
@@ -9,7 +9,7 @@ import (
 
 type UserUsecase interface {
 	Create(ctx context.Context, u *entities.PortalUser) error
-	List(ctx context.Context) ([]*entities.PortalUser, error)
+	List(ctx context.Context, filter *entities.UserFilter) ([]*entities.PortalUser, int, error)
 	Get(ctx context.Context, id uuid.UUID) (*entities.PortalUser, error)
 	Update(ctx context.Context, u *entities.PortalUser) error
 	Delete(ctx context.Context, id uuid.UUID) error

--- a/internal/domains/portal/usecases/user_usecase_impl.go
+++ b/internal/domains/portal/usecases/user_usecase_impl.go
@@ -40,8 +40,8 @@ func (u *userUsecaseImpl) Create(ctx context.Context, user *entities.PortalUser)
 	return u.repo.Create(ctx, user)
 }
 
-func (u *userUsecaseImpl) List(ctx context.Context) ([]*entities.PortalUser, error) {
-	return u.repo.List(ctx)
+func (u *userUsecaseImpl) List(ctx context.Context, filter *entities.UserFilter) ([]*entities.PortalUser, int, error) {
+	return u.repo.List(ctx, filter)
 }
 
 func (u *userUsecaseImpl) Get(ctx context.Context, id uuid.UUID) (*entities.PortalUser, error) {

--- a/internal/domains/portal/usecases/user_usecase_impl.go
+++ b/internal/domains/portal/usecases/user_usecase_impl.go
@@ -56,12 +56,10 @@ func (u *userUsecaseImpl) Update(ctx context.Context, user *entities.PortalUser)
 	if existing == nil {
 		return fmt.Errorf("user not found")
 	}
-	if other, _ := u.repo.GetByUsername(ctx, user.Username); other != nil && other.ID != user.ID {
-		return fmt.Errorf("username already exists")
-	}
-	if other, _ := u.repo.GetByEmail(ctx, user.Email); other != nil && other.ID != user.ID {
-		return fmt.Errorf("email already exists")
-	}
+	// username and email should not be updated; keep existing values
+	user.Username = existing.Username
+	user.Email = existing.Email
+
 	if g, _ := u.groupRepo.GetByID(ctx, user.GroupID); g == nil {
 		return fmt.Errorf("group not found")
 	}
@@ -71,6 +69,8 @@ func (u *userUsecaseImpl) Update(ctx context.Context, user *entities.PortalUser)
 			return err
 		}
 		user.Password = string(hash)
+	} else {
+		user.Password = existing.Password
 	}
 	return u.repo.Update(ctx, user)
 }

--- a/internal/shared/config/config.go
+++ b/internal/shared/config/config.go
@@ -50,8 +50,8 @@ type JWTConfig struct {
 
 	// RSA configuration (recommended)
 	UseRSA                     bool          `mapstructure:"useRSA"`
-	AccessPrivateKey           string        `mapstructure:"accessPrivateKey"`
-	RefreshPrivateKey          string        `mapstructure:"refreshPrivateKey"`
+	AccessPrivateKeyPath       string        `mapstructure:"accessPrivateKeyPath"`
+	RefreshPrivateKeyPath      string        `mapstructure:"refreshPrivateKeyPath"`
 	AccessTokenExpireDuration  time.Duration `mapstructure:"accessTokenExpireDuration"`
 	RefreshTokenExpireDuration time.Duration `mapstructure:"refreshTokenExpireDuration"`
 }
@@ -128,6 +128,8 @@ func setDefaults() {
 
 	// JWT defaults
 	viper.SetDefault("jwt.useRSA", true)
+	viper.SetDefault("jwt.accessPrivateKeyPath", "")
+	viper.SetDefault("jwt.refreshPrivateKeyPath", "")
 	viper.SetDefault("jwt.accessTokenExpireDuration", time.Hour)
 	viper.SetDefault("jwt.refreshTokenExpireDuration", 24*time.Hour)
 

--- a/internal/shared/config/config.go
+++ b/internal/shared/config/config.go
@@ -7,15 +7,11 @@ import (
 
 	"github.com/spf13/viper"
 
-	ldapCfg "system-portal/internal/shared/infrastructure/ldap"
-	xmlrpcCfg "system-portal/internal/shared/infrastructure/xmlrpc"
 	"system-portal/pkg/logger"
 )
 
 type Config struct {
 	Server   ServerConfig   `mapstructure:"server"`
-	OpenVPN  OpenVPNConfig  `mapstructure:"openvpn"`
-	LDAP     LDAPConfig     `mapstructure:"ldap"`
 	Database DatabaseConfig `mapstructure:"database"`
 	Logger   LoggerConfig   `mapstructure:"logger"`
 	JWT      JWTConfig      `mapstructure:"jwt"`
@@ -28,10 +24,6 @@ type ServerConfig struct {
 	Mode    string `mapstructure:"mode"`
 	Timeout int    `mapstructure:"timeout"`
 }
-
-type OpenVPNConfig = xmlrpcCfg.Config
-
-type LDAPConfig = ldapCfg.Config
 
 // Database connection settings
 type DatabaseConfig struct {
@@ -129,12 +121,6 @@ func setDefaults() {
 	viper.SetDefault("server.port", "8080")
 	viper.SetDefault("server.mode", "debug")
 	viper.SetDefault("server.timeout", 30)
-
-	// OpenVPN defaults
-	viper.SetDefault("openvpn.port", 943)
-
-	// LDAP defaults
-	viper.SetDefault("ldap.port", 389)
 
 	// Logger defaults
 	viper.SetDefault("logger.level", "info")

--- a/internal/shared/config/config.go
+++ b/internal/shared/config/config.go
@@ -71,6 +71,7 @@ type RedisConfig struct {
 type SecurityConfig struct {
 	EnableSecurityHeaders bool       `mapstructure:"enableSecurityHeaders"`
 	CORS                  CORSConfig `mapstructure:"cors"`
+	EncryptionKey         string     `mapstructure:"encryptionKey"`
 }
 
 type CORSConfig struct {
@@ -160,4 +161,5 @@ func setDefaults() {
 	viper.SetDefault("security.cors.allowedMethods", []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"})
 	viper.SetDefault("security.cors.allowedHeaders", []string{"Authorization", "Content-Type"})
 	viper.SetDefault("security.cors.allowCredentials", true)
+	viper.SetDefault("security.encryptionKey", "")
 }

--- a/internal/shared/infrastructure/http/router.go
+++ b/internal/shared/infrastructure/http/router.go
@@ -37,6 +37,7 @@ type Router struct {
 	authMiddleware       *middleware.AuthMiddleware
 	corsMiddleware       *middleware.CorsMiddleware
 	validationMiddleware *middleware.ValidationMiddleware
+	auditMiddleware      *middleware.AuditMiddleware
 }
 
 func NewRouter(
@@ -44,12 +45,14 @@ func NewRouter(
 	authMiddleware *middleware.AuthMiddleware,
 	corsMiddleware *middleware.CorsMiddleware,
 	validationMiddleware *middleware.ValidationMiddleware,
+	auditMiddleware *middleware.AuditMiddleware,
 ) *Router {
 	return &Router{
 		config:               config,
 		authMiddleware:       authMiddleware,
 		corsMiddleware:       corsMiddleware,
 		validationMiddleware: validationMiddleware,
+		auditMiddleware:      auditMiddleware,
 	}
 }
 
@@ -70,6 +73,9 @@ func (r *Router) SetupRoutes() *gin.Engine {
 	router.Use(r.corsMiddleware.Handler())
 	router.Use(r.corsMiddleware.SecurityHeaders())
 	router.Use(r.validationMiddleware.StrictJSONBinding())
+	if r.auditMiddleware != nil {
+		router.Use(r.auditMiddleware.Handler())
+	}
 
 	// Timeout middleware
 	router.Use(timeout.New(

--- a/internal/shared/infrastructure/http/router.go
+++ b/internal/shared/infrastructure/http/router.go
@@ -222,9 +222,6 @@ func (r *Router) setupProtectedRoutes(router *gin.Engine) {
 	authRoutes.RegisterProtectedRoutes(protected)
 	portalRoutes.RegisterRoutes(protected)
 	openvpnRoutes.SetRouterGroup(protected)
-	if openvpnRoutes.Enabled() {
-		openvpnRoutes.RegisterRoutes(protected)
-	}
 }
 
 // ✅ ENHANCED: healthCheck with more detailed information

--- a/internal/shared/infrastructure/http/router.go
+++ b/internal/shared/infrastructure/http/router.go
@@ -221,7 +221,9 @@ func (r *Router) setupProtectedRoutes(router *gin.Engine) {
 	// Register domain routes
 	authRoutes.RegisterProtectedRoutes(protected)
 	portalRoutes.RegisterRoutes(protected)
-	openvpnRoutes.RegisterRoutes(protected)
+	if openvpnRoutes.Enabled() {
+		openvpnRoutes.RegisterRoutes(protected)
+	}
 }
 
 // ✅ ENHANCED: healthCheck with more detailed information

--- a/internal/shared/infrastructure/http/router.go
+++ b/internal/shared/infrastructure/http/router.go
@@ -221,6 +221,7 @@ func (r *Router) setupProtectedRoutes(router *gin.Engine) {
 	// Register domain routes
 	authRoutes.RegisterProtectedRoutes(protected)
 	portalRoutes.RegisterRoutes(protected)
+	openvpnRoutes.SetRouterGroup(protected)
 	if openvpnRoutes.Enabled() {
 		openvpnRoutes.RegisterRoutes(protected)
 	}

--- a/internal/shared/infrastructure/http/router.go
+++ b/internal/shared/infrastructure/http/router.go
@@ -3,7 +3,6 @@ package http
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -22,6 +21,7 @@ import (
 	portalRoutes "system-portal/internal/domains/portal/routes"
 	"system-portal/internal/shared/middleware"
 	response "system-portal/internal/shared/response"
+	"system-portal/pkg/logger"
 )
 
 type RouterConfig struct {
@@ -114,9 +114,9 @@ func (r *Router) StartServer() error {
 	go func() {
 		r.logStartupInfo()
 
-		log.Printf("🚀 Starting System Portal API v2.0.0 on port %s", r.config.Port)
+		logger.Log.Infof("Starting System Portal API on port %s", r.config.Port)
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("❌ Failed to start server: %v", err)
+			logger.Log.Fatalf("Failed to start server: %v", err)
 		}
 	}()
 
@@ -139,9 +139,9 @@ func (r *Router) StartServerWithTLS(certFile, keyFile string) error {
 	go func() {
 		r.logStartupInfo()
 
-		log.Printf("🔒 Starting HTTPS System Portal API v2.0.0 on port %s", r.config.Port)
+		logger.Log.Infof("Starting HTTPS System Portal API on port %s", r.config.Port)
 		if err := server.ListenAndServeTLS(certFile, keyFile); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("❌ Failed to start HTTPS server: %v", err)
+			logger.Log.Fatalf("Failed to start HTTPS server: %v", err)
 		}
 	}()
 
@@ -150,23 +150,19 @@ func (r *Router) StartServerWithTLS(certFile, keyFile string) error {
 
 // ✅ NEW: logStartupInfo logs server startup information
 func (r *Router) logStartupInfo() {
-	log.Println(strings.Repeat("=", 60))
-	log.Printf("🏢 Service: System Portal API")
-	log.Printf("📊 Version: 2.0.0")
-	log.Printf("🏗️  Architecture: Domain-Driven Design")
-	log.Printf("🌐 Server: http://localhost:%s", r.config.Port)
-	log.Printf("📚 Documentation: http://localhost:%s/swagger/index.html", r.config.Port)
-	log.Printf("🏥 Health Check: http://localhost:%s/health", r.config.Port)
-	log.Printf("⚙️  Mode: %s", r.config.Mode)
-	log.Printf("⏱️  Request Timeout: %v", r.config.TimeoutDuration)
-	log.Printf("📖 Read Timeout: %v", r.config.ReadTimeout)
-	log.Printf("✍️  Write Timeout: %v", r.config.WriteTimeout)
-	log.Println(strings.Repeat("=", 60))
-	log.Printf("🎯 Domains Available:")
-	log.Printf("   🔐 Auth: /auth/*")
-	log.Printf("   🏢 Portal: /api/portal/*")
-	log.Printf("   🔌 OpenVPN: /api/openvpn/*")
-	log.Println(strings.Repeat("=", 60))
+	logger.Log.Info(strings.Repeat("=", 60))
+	logger.Log.Info("Service: System Portal API")
+	logger.Log.Info("Version: 2.0.0")
+	logger.Log.Infof("Server: http://localhost:%s", r.config.Port)
+	logger.Log.Infof("Documentation: http://localhost:%s/swagger/index.html", r.config.Port)
+	logger.Log.Infof("Health Check: http://localhost:%s/health", r.config.Port)
+	logger.Log.Infof("Mode: %s", r.config.Mode)
+	logger.Log.Infof("Request Timeout: %v", r.config.TimeoutDuration)
+	logger.Log.Infof("Read Timeout: %v", r.config.ReadTimeout)
+	logger.Log.Infof("Write Timeout: %v", r.config.WriteTimeout)
+	logger.Log.Info(strings.Repeat("=", 60))
+	logger.Log.Info("Domains Available: auth, portal, openvpn")
+	logger.Log.Info(strings.Repeat("=", 60))
 }
 
 // ✅ NEW: waitForShutdown handles graceful shutdown
@@ -179,7 +175,7 @@ func (r *Router) waitForShutdown(server *http.Server) error {
 
 	// Block until signal is received
 	sig := <-quit
-	log.Printf("🔄 Received signal: %v. Shutting down server...", sig)
+	logger.Log.Infof("Received signal: %v. Shutting down server...", sig)
 
 	// Create context with timeout for graceful shutdown
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -189,11 +185,11 @@ func (r *Router) waitForShutdown(server *http.Server) error {
 	server.SetKeepAlivesEnabled(false)
 
 	if err := server.Shutdown(ctx); err != nil {
-		log.Printf("❌ Server forced to shutdown: %v", err)
+		logger.Log.Errorf("Server forced to shutdown: %v", err)
 		return err
 	}
 
-	log.Println("✅ Server exited gracefully")
+	logger.Log.Info("Server exited gracefully")
 	return nil
 }
 

--- a/internal/shared/middleware/audit_middleware.go
+++ b/internal/shared/middleware/audit_middleware.go
@@ -4,23 +4,48 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"system-portal/internal/domains/portal/entities"
+	"system-portal/internal/domains/portal/usecases"
 	"system-portal/pkg/logger"
 )
 
 // AuditMiddleware logs simple request information.
-type AuditMiddleware struct{}
+type AuditMiddleware struct {
+	uc usecases.AuditUsecase
+}
 
-func NewAuditMiddleware() *AuditMiddleware { return &AuditMiddleware{} }
+func NewAuditMiddleware(u usecases.AuditUsecase) *AuditMiddleware { return &AuditMiddleware{uc: u} }
 
 func (a *AuditMiddleware) Handler() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 		c.Next()
+		duration := time.Since(start)
 		logger.Log.WithFields(map[string]interface{}{
 			"method":   c.Request.Method,
 			"path":     c.Request.URL.Path,
 			"status":   c.Writer.Status(),
-			"duration": time.Since(start).String(),
+			"duration": duration.String(),
 		}).Info("request handled")
+
+		if a.uc != nil {
+			logEntry := &entities.AuditLog{
+				ID:        uuid.New(),
+				Action:    c.Request.Method,
+				Resource:  c.Request.URL.Path,
+				Success:   c.Writer.Status() < 400,
+				CreatedAt: time.Now(),
+			}
+			// Username is available via context but user ID lookup is omitted
+			if uname, ok := c.Get("username"); ok {
+				if name, ok := uname.(string); ok {
+					logEntry.Action = name + " " + logEntry.Action
+				}
+			}
+			if err := a.uc.Add(c.Request.Context(), logEntry); err != nil {
+				logger.Log.WithError(err).Warn("failed to add audit log")
+			}
+		}
 	}
 }

--- a/internal/shared/middleware/audit_middleware.go
+++ b/internal/shared/middleware/audit_middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -37,17 +38,25 @@ func (a *AuditMiddleware) Handler() gin.HandlerFunc {
 
 		if a.uc != nil && (c.Request.Method == http.MethodPost || c.Request.Method == http.MethodPut || c.Request.Method == http.MethodDelete) {
 			logEntry := &entities.AuditLog{
-				ID:        uuid.New(),
-				Action:    c.Request.Method,
-				Resource:  c.Request.URL.Path,
-				Success:   c.Writer.Status() < 400,
-				CreatedAt: time.Now(),
+				ID:         uuid.New(),
+				Action:     c.Request.Method,
+				Resource:   c.Request.URL.Path,
+				Success:    c.Writer.Status() < 400,
+				CreatedAt:  time.Now(),
+				DurationMs: int(duration.Milliseconds()),
+				IPAddress:  c.ClientIP(),
+				UserAgent:  c.Request.UserAgent(),
 			}
 
+			if uid, ok := c.Get("userID"); ok {
+				if id, ok := uid.(uuid.UUID); ok {
+					logEntry.UserID = id
+				}
+			}
 			if uname, ok := c.Get("username"); ok {
 				if name, ok := uname.(string); ok {
 					logEntry.Username = name
-					if a.users != nil {
+					if logEntry.UserID == uuid.Nil && a.users != nil {
 						if usr, err := a.users.GetByUsername(c.Request.Context(), name); err == nil && usr != nil {
 							logEntry.UserID = usr.ID
 							if a.groups != nil {
@@ -63,6 +72,10 @@ func (a *AuditMiddleware) Handler() gin.HandlerFunc {
 				if g, ok := group.(string); ok {
 					logEntry.UserGroup = g
 				}
+			}
+
+			if len(c.Errors) > 0 {
+				logEntry.ErrorMessage = strings.Join(c.Errors.Errors(), "; ")
 			}
 
 			if err := a.uc.Add(c.Request.Context(), logEntry); err != nil {

--- a/internal/shared/middleware/audit_middleware.go
+++ b/internal/shared/middleware/audit_middleware.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -34,7 +35,7 @@ func (a *AuditMiddleware) Handler() gin.HandlerFunc {
 			"duration": duration.String(),
 		}).Info("request handled")
 
-		if a.uc != nil {
+		if a.uc != nil && (c.Request.Method == http.MethodPost || c.Request.Method == http.MethodPut || c.Request.Method == http.MethodDelete) {
 			logEntry := &entities.AuditLog{
 				ID:        uuid.New(),
 				Action:    c.Request.Method,

--- a/internal/shared/middleware/audit_middleware.go
+++ b/internal/shared/middleware/audit_middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -36,14 +37,20 @@ func (a *AuditMiddleware) Handler() gin.HandlerFunc {
 		}).Info("request handled")
 
 		if a.uc != nil && (c.Request.Method == http.MethodPost || c.Request.Method == http.MethodPut || c.Request.Method == http.MethodDelete) {
+			resourceType := ""
+			full := strings.Trim(c.FullPath(), "/")
+			if full != "" {
+				parts := strings.Split(full, "/")
+				resourceType = parts[0]
+			}
 			logEntry := &entities.AuditLog{
 				ID:           uuid.New(),
 				Action:       c.Request.Method,
-				Resource:     c.Request.URL.Path,
-				Success:      c.Writer.Status() < 400,
-				CreatedAt:    time.Now(),
+				ResourceType: resourceType,
 				ResourceName: c.FullPath(),
 				IPAddress:    c.ClientIP(),
+				Success:      c.Writer.Status() < 400,
+				CreatedAt:    time.Now(),
 			}
 
 			if uid, ok := c.Get("userID"); ok {

--- a/internal/shared/middleware/permission_middleware.go
+++ b/internal/shared/middleware/permission_middleware.go
@@ -5,39 +5,45 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	portalrepos "system-portal/internal/domains/portal/repositories"
 )
 
-// RequirePermission is a very small placeholder for RBAC permission checks.
-// It simply blocks non-admin roles.
-func RequirePermission(permission string) gin.HandlerFunc {
+// PermissionMiddleware performs RBAC checks using group permissions.
+type PermissionMiddleware struct {
+	perms  portalrepos.PermissionRepository
+	groups portalrepos.GroupRepository
+}
+
+func NewPermissionMiddleware(p portalrepos.PermissionRepository, g portalrepos.GroupRepository) *PermissionMiddleware {
+	return &PermissionMiddleware{perms: p, groups: g}
+}
+
+func (m *PermissionMiddleware) RequirePermission(perm string) gin.HandlerFunc {
+	parts := strings.SplitN(perm, ".", 2)
+	if len(parts) != 2 {
+		return func(c *gin.Context) { c.Next() }
+	}
+	resource, action := parts[0], parts[1]
 	return func(c *gin.Context) {
 		role := c.GetString("role")
-		if strings.ToLower(role) != "admin" {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error": gin.H{
-					"code":    "FORBIDDEN",
-					"message": "insufficient permissions",
-					"status":  http.StatusForbidden,
-				},
-			})
+		if role == "" {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "FORBIDDEN", "message": "forbidden", "status": http.StatusForbidden}})
+			return
+		}
+		allowed, err := m.perms.HasGroupPermission(c.Request.Context(), role, resource, action)
+		if err != nil || !allowed {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "FORBIDDEN", "message": "insufficient permissions", "status": http.StatusForbidden}})
 			return
 		}
 		c.Next()
 	}
 }
 
-// RequireGroup ensures the authenticated user belongs to the specified group.
 func RequireGroup(group string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		role := c.GetString("role")
 		if strings.ToLower(role) != strings.ToLower(group) {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
-				"error": gin.H{
-					"code":    "FORBIDDEN",
-					"message": "forbidden",
-					"status":  http.StatusForbidden,
-				},
-			})
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": gin.H{"code": "FORBIDDEN", "message": "forbidden", "status": http.StatusForbidden}})
 			return
 		}
 		c.Next()

--- a/internal/shared/response/response.go
+++ b/internal/shared/response/response.go
@@ -44,6 +44,9 @@ func RespondWithSuccess(c *gin.Context, status int, data interface{}) {
 	response.Success.Status = status
 	response.Success.Data = data
 
+	// Prevent sensitive data from being cached
+	c.Header("Cache-Control", "no-store")
+
 	c.JSON(status, response)
 }
 
@@ -52,6 +55,8 @@ func RespondWithMessage(c *gin.Context, status int, message string) {
 	response := SuccessResponse{}
 	response.Success.Status = status
 	response.Success.Message = message
+
+	c.Header("Cache-Control", "no-store")
 
 	c.JSON(status, response)
 }
@@ -62,6 +67,8 @@ func RespondWithError(c *gin.Context, err *errors.AppError) {
 	response.Error.Code = err.Code
 	response.Error.Message = err.Message
 	response.Error.Status = err.Status
+
+	c.Header("Cache-Control", "no-store")
 
 	c.JSON(err.Status, response)
 }
@@ -110,6 +117,7 @@ func RespondWithValidationError(c *gin.Context, err error) {
 		response.Error.Fields["general"] = err.Error()
 	}
 
+	c.Header("Cache-Control", "no-store")
 	c.JSON(http.StatusBadRequest, response)
 }
 
@@ -119,6 +127,8 @@ func RespondWithInternalError(c *gin.Context, message string) {
 	response.Error.Code = "INTERNAL_SERVER_ERROR"
 	response.Error.Message = message
 	response.Error.Status = http.StatusInternalServerError
+
+	c.Header("Cache-Control", "no-store")
 
 	c.JSON(http.StatusInternalServerError, response)
 }
@@ -130,6 +140,8 @@ func RespondWithNotFound(c *gin.Context, message string) {
 	response.Error.Message = message
 	response.Error.Status = http.StatusNotFound
 
+	c.Header("Cache-Control", "no-store")
+
 	c.JSON(http.StatusNotFound, response)
 }
 
@@ -139,6 +151,8 @@ func RespondWithBadRequest(c *gin.Context, message string) {
 	response.Error.Code = "BAD_REQUEST"
 	response.Error.Message = message
 	response.Error.Status = http.StatusBadRequest
+
+	c.Header("Cache-Control", "no-store")
 
 	c.JSON(http.StatusBadRequest, response)
 }
@@ -150,6 +164,8 @@ func RespondWithUnauthorized(c *gin.Context, message string) {
 	response.Error.Message = message
 	response.Error.Status = http.StatusUnauthorized
 
+	c.Header("Cache-Control", "no-store")
+
 	c.JSON(http.StatusUnauthorized, response)
 }
 
@@ -160,6 +176,8 @@ func RespondWithForbidden(c *gin.Context, message string) {
 	response.Error.Message = message
 	response.Error.Status = http.StatusForbidden
 
+	c.Header("Cache-Control", "no-store")
+
 	c.JSON(http.StatusForbidden, response)
 }
 
@@ -169,6 +187,8 @@ func RespondWithConflict(c *gin.Context, message string) {
 	response.Error.Code = "CONFLICT"
 	response.Error.Message = message
 	response.Error.Status = http.StatusConflict
+
+	c.Header("Cache-Control", "no-store")
 
 	c.JSON(http.StatusConflict, response)
 }

--- a/migrations/001_create_tables.sql
+++ b/migrations/001_create_tables.sql
@@ -1,5 +1,7 @@
 -- Enable UUID extension
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+-- Enable pgcrypto for crypt() function used in seed data
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 -- Groups table
 CREATE TABLE IF NOT EXISTS groups (

--- a/migrations/001_create_tables.sql
+++ b/migrations/001_create_tables.sql
@@ -32,8 +32,8 @@ CREATE TABLE IF NOT EXISTS users (
 CREATE TABLE IF NOT EXISTS user_sessions (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    token_hash VARCHAR(255) NOT NULL,
-    refresh_token_hash VARCHAR(255),
+    token_hash TEXT NOT NULL,
+    refresh_token_hash TEXT,
     expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
     refresh_expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
     is_active BOOLEAN DEFAULT TRUE,

--- a/migrations/001_create_tables.sql
+++ b/migrations/001_create_tables.sql
@@ -51,15 +51,9 @@ CREATE TABLE IF NOT EXISTS audit_logs (
     user_group VARCHAR(50),
     action VARCHAR(100) NOT NULL,
     resource_type VARCHAR(50) NOT NULL,
-    resource_id VARCHAR(100),
     resource_name VARCHAR(200),
-    old_values JSONB,
-    new_values JSONB,
     ip_address INET,
-    user_agent TEXT,
     success BOOLEAN DEFAULT TRUE,
-    error_message TEXT,
-    duration_ms INTEGER,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 

--- a/migrations/002_seed_data.sql
+++ b/migrations/002_seed_data.sql
@@ -7,21 +7,39 @@ ON CONFLICT (name) DO NOTHING;
 
 -- Insert default permissions
 INSERT INTO permissions (resource, action, description) VALUES
+    -- Portal permissions
     ('portal', 'manage_users', 'Manage portal users'),
     ('portal', 'view_users', 'View portal users'),
-    ('openvpn', 'manage_users', 'Manage OpenVPN users'),
+    -- OpenVPN user permissions
+    ('openvpn', 'view_users', 'View OpenVPN users'),
+    ('openvpn', 'create_users', 'Create OpenVPN users'),
+    ('openvpn', 'edit_users', 'Edit OpenVPN users'),
+    ('openvpn', 'delete_users', 'Delete OpenVPN users'),
+    -- OpenVPN group permissions
+    ('openvpn', 'view_groups', 'View OpenVPN groups'),
+    ('openvpn', 'manage_groups', 'Manage OpenVPN groups'),
+    -- OpenVPN status permissions
     ('openvpn', 'view_status', 'View OpenVPN status')
 ON CONFLICT (resource, action) DO NOTHING;
 
 -- Assign permissions to groups
+-- Admin gets all permissions
 INSERT INTO group_permissions (group_id, permission_id)
-SELECT g.id, p.id FROM groups g, permissions p WHERE g.name = 'admin'
+SELECT g.id, p.id FROM groups g, permissions p
+WHERE g.name = 'admin'
 ON CONFLICT DO NOTHING;
 
 -- Support group permissions (limited)
+-- Support group has limited permissions
 INSERT INTO group_permissions (group_id, permission_id)
 SELECT g.id, p.id FROM groups g
-JOIN permissions p ON (p.resource, p.action) IN (( 'openvpn', 'manage_users' ), ( 'openvpn', 'view_status' ))
+JOIN permissions p ON (p.resource, p.action) IN (
+    ( 'openvpn', 'view_users' ),
+    ( 'openvpn', 'create_users' ),
+    ( 'openvpn', 'edit_users' ),
+    ( 'openvpn', 'view_groups' ),
+    ( 'openvpn', 'view_status' )
+)
 WHERE g.name = 'support'
 ON CONFLICT DO NOTHING;
 

--- a/migrations/002_seed_data.sql
+++ b/migrations/002_seed_data.sql
@@ -25,23 +25,23 @@ JOIN permissions p ON (p.resource, p.action) IN (( 'openvpn', 'manage_users' ), 
 WHERE g.name = 'support'
 ON CONFLICT DO NOTHING;
 
--- Create initial admin user
+-- Create initial admin user with low-cost bcrypt hash
 INSERT INTO users (username, email, password_hash, full_name, group_id)
 VALUES (
     'admin',
     'admin@company.com',
-    '$2b$14$0a4r3Cs1ed6D3lekeUFrTu8axaBGnuAuIan6Y9gHnNuAVRAaDbrQi',
+    crypt('admin123', gen_salt('bf', 10)),
     'System Administrator',
     (SELECT id FROM groups WHERE name = 'admin')
 )
 ON CONFLICT (username) DO NOTHING;
 
--- Create initial support user
+-- Create initial support user with low-cost bcrypt hash
 INSERT INTO users (username, email, password_hash, full_name, group_id)
 VALUES (
     'support',
     'support@company.com',
-    '$2b$14$0a4r3Cs1ed6D3lekeUFrTu8axaBGnuAuIan6Y9gHnNuAVRAaDbrQi',
+    crypt('support123', gen_salt('bf', 10)),
     'Support Staff',
     (SELECT id FROM groups WHERE name = 'support')
 )

--- a/migrations/003_connection_config.sql
+++ b/migrations/003_connection_config.sql
@@ -1,0 +1,22 @@
+-- OpenVPN connection configuration
+CREATE TABLE IF NOT EXISTS openvpn_configs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    host VARCHAR(100) NOT NULL,
+    username VARCHAR(100) NOT NULL,
+    password VARCHAR(100) NOT NULL,
+    port INT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- LDAP connection configuration
+CREATE TABLE IF NOT EXISTS ldap_configs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    host VARCHAR(100) NOT NULL,
+    port INT NOT NULL,
+    bind_dn VARCHAR(100) NOT NULL,
+    bind_password VARCHAR(100) NOT NULL,
+    base_dn VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);

--- a/migrations/003_connection_config.sql
+++ b/migrations/003_connection_config.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS openvpn_configs (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     host VARCHAR(100) NOT NULL,
     username VARCHAR(100) NOT NULL,
-    password VARCHAR(100) NOT NULL,
+    password TEXT NOT NULL,
     port INT NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS ldap_configs (
     host VARCHAR(100) NOT NULL,
     port INT NOT NULL,
     bind_dn VARCHAR(100) NOT NULL,
-    bind_password VARCHAR(100) NOT NULL,
+    bind_password TEXT NOT NULL,
     base_dn VARCHAR(100) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()

--- a/pkg/utils/crypto.go
+++ b/pkg/utils/crypto.go
@@ -1,0 +1,68 @@
+package utils
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+)
+
+// EncryptString encrypts plain text using AES-GCM and returns base64 encoded ciphertext.
+func EncryptString(plain, key string) (string, error) {
+	if key == "" {
+		return plain, nil
+	}
+	bkey := []byte(key)
+	if len(bkey) != 32 {
+		return "", fmt.Errorf("encryption key must be 32 bytes")
+	}
+	block, err := aes.NewCipher(bkey)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	cipherText := gcm.Seal(nonce, nonce, []byte(plain), nil)
+	return base64.StdEncoding.EncodeToString(cipherText), nil
+}
+
+// DecryptString decrypts a base64 encoded ciphertext using AES-GCM.
+func DecryptString(cipherText, key string) (string, error) {
+	if key == "" {
+		return cipherText, nil
+	}
+	data, err := base64.StdEncoding.DecodeString(cipherText)
+	if err != nil {
+		return "", err
+	}
+	bkey := []byte(key)
+	if len(bkey) != 32 {
+		return "", fmt.Errorf("encryption key must be 32 bytes")
+	}
+	block, err := aes.NewCipher(bkey)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+	if len(data) < gcm.NonceSize() {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+	nonce := data[:gcm.NonceSize()]
+	ciphertext := data[gcm.NonceSize():]
+	plain, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}

--- a/pkg/utils/hash.go
+++ b/pkg/utils/hash.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// HashString returns a SHA-256 hash of the given string in hexadecimal format.
+func HashString(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}


### PR DESCRIPTION
## Summary
- hash tokens before storing sessions to prevent database truncation
- widen session token columns to TEXT
- add audit middleware that records requests
- wire audit middleware into router and server startup
- provide SHA-256 helper

## Testing
- `go test ./...` *(fails: proxy access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856c51c3e4c832ca22a9bad7c1ee5bb