### PR TITLE
Add database-driven email templates

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4314,7 +4314,7 @@
             "type": "object",
             "properties": {
                 "subject": {"type": "string"},
-                "body": {"type": "string"}
+                "body": {"type": "string", "description": "HTML content template"}
             },
             "required": ["subject", "body"]
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2020,6 +2020,82 @@
                 }
             }
         },
+        "/api/portal/connections/smtp": {
+            "get": {
+                "security": [{"BearerAuth": []}],
+                "produces": ["application/json"],
+                "tags": ["Connections"],
+                "summary": "Get SMTP configuration",
+                "responses": {
+                    "200": {"description": "OK", "schema": {"$ref": "#/definitions/entities.SMTPConfig"}},
+                    "404": {"description": "Not Found", "schema": {"$ref": "#/definitions/response.ErrorResponse"}}
+                }
+            },
+            "post": {
+                "security": [{"BearerAuth": []}],
+                "consumes": ["application/json"],
+                "produces": ["application/json"],
+                "tags": ["Connections"],
+                "summary": "Create SMTP configuration",
+                "parameters": [
+                    {"description": "SMTP config", "name": "request", "in": "body", "required": true, "schema": {"$ref": "#/definitions/dto.SMTPConfigRequest"}}
+                ],
+                "responses": {
+                    "201": {"description": "created", "schema": {"$ref": "#/definitions/response.SuccessResponse"}}
+                }
+            },
+            "put": {
+                "security": [{"BearerAuth": []}],
+                "consumes": ["application/json"],
+                "produces": ["application/json"],
+                "tags": ["Connections"],
+                "summary": "Update SMTP configuration",
+                "parameters": [
+                    {"description": "SMTP config", "name": "request", "in": "body", "required": true, "schema": {"$ref": "#/definitions/dto.SMTPConfigRequest"}}
+                ],
+                "responses": {
+                    "200": {"description": "OK", "schema": {"$ref": "#/definitions/response.SuccessResponse"}}
+                }
+            },
+            "delete": {
+                "security": [{"BearerAuth": []}],
+                "produces": ["application/json"],
+                "tags": ["Connections"],
+                "summary": "Delete SMTP configuration",
+                "responses": {
+                    "200": {"description": "OK", "schema": {"$ref": "#/definitions/response.SuccessResponse"}}
+                }
+            }
+        },
+        "/api/portal/connections/templates/{action}": {
+            "get": {
+                "security": [{"BearerAuth": []}],
+                "produces": ["application/json"],
+                "tags": ["Connections"],
+                "summary": "Get email template by action",
+                "parameters": [
+                    {"type": "string", "description": "action", "name": "action", "in": "path", "required": true}
+                ],
+                "responses": {
+                    "200": {"description": "OK", "schema": {"$ref": "#/definitions/entities.EmailTemplate"}},
+                    "404": {"description": "Not Found", "schema": {"$ref": "#/definitions/response.ErrorResponse"}}
+                }
+            },
+            "put": {
+                "security": [{"BearerAuth": []}],
+                "consumes": ["application/json"],
+                "produces": ["application/json"],
+                "tags": ["Connections"],
+                "summary": "Update email template",
+                "parameters": [
+                    {"type": "string", "description": "action", "name": "action", "in": "path", "required": true},
+                    {"description": "template", "name": "request", "in": "body", "required": true, "schema": {"$ref": "#/definitions/dto.EmailTemplateRequest"}}
+                ],
+                "responses": {
+                    "200": {"description": "OK", "schema": {"$ref": "#/definitions/response.SuccessResponse"}}
+                }
+            }
+        },
         "/api/portal/users": {
             "get": {
                 "security": [
@@ -4196,6 +4272,51 @@
                     "type": "string"
                 }
             }
+        },
+        "entities.SMTPConfig": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "host": {"type": "string"},
+                "port": {"type": "integer"},
+                "username": {"type": "string"},
+                "password": {"type": "string"},
+                "from": {"type": "string"},
+                "tls": {"type": "boolean"},
+                "createdAt": {"type": "string"},
+                "updatedAt": {"type": "string"}
+            }
+        },
+        "dto.SMTPConfigRequest": {
+            "type": "object",
+            "properties": {
+                "host": {"type": "string"},
+                "port": {"type": "integer"},
+                "username": {"type": "string"},
+                "password": {"type": "string"},
+                "from": {"type": "string"},
+                "tls": {"type": "boolean"}
+            },
+            "required": ["host", "port", "from"]
+        },
+        "entities.EmailTemplate": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "action": {"type": "string"},
+                "subject": {"type": "string"},
+                "body": {"type": "string"},
+                "createdAt": {"type": "string"},
+                "updatedAt": {"type": "string"}
+            }
+        },
+        "dto.EmailTemplateRequest": {
+            "type": "object",
+            "properties": {
+                "subject": {"type": "string"},
+                "body": {"type": "string"}
+            },
+            "required": ["subject", "body"]
         },
         "response.ErrorResponse": {
             "type": "object",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1212,8 +1212,73 @@ definitions:
         items:
           $ref: '#/definitions/entities.Permission'
         type: array
+    updatedAt:
+      type: string
+    type: object
+  entities.SMTPConfig:
+    properties:
+      id:
+        type: string
+      host:
+        type: string
+      port:
+        type: integer
+      username:
+        type: string
+      password:
+        type: string
+      from:
+        type: string
+      tls:
+        type: boolean
+      createdAt:
+        type: string
       updatedAt:
         type: string
+    type: object
+  dto.SMTPConfigRequest:
+    properties:
+      host:
+        type: string
+      port:
+        type: integer
+      username:
+        type: string
+      password:
+        type: string
+      from:
+        type: string
+      tls:
+        type: boolean
+    required:
+    - host
+    - port
+    - from
+    type: object
+  entities.EmailTemplate:
+    properties:
+      id:
+        type: string
+      action:
+        type: string
+      subject:
+        type: string
+      body:
+        type: string
+      createdAt:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  dto.EmailTemplateRequest:
+    properties:
+      subject:
+        type: string
+      body:
+        type: string
+    required:
+    - subject
+    - body
     type: object
   response.ErrorResponse:
     properties:
@@ -2620,6 +2685,132 @@ paths:
       summary: Delete permission
       tags:
       - Permissions
+  /api/portal/connections/smtp:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/entities.SMTPConfig'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/response.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get SMTP configuration
+      tags:
+      - Connections
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: SMTP config
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SMTPConfigRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: created
+          schema:
+            $ref: '#/definitions/response.SuccessResponse'
+      security:
+      - BearerAuth: []
+      summary: Create SMTP configuration
+      tags:
+      - Connections
+    put:
+      consumes:
+      - application/json
+      parameters:
+      - description: SMTP config
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.SMTPConfigRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.SuccessResponse'
+      security:
+      - BearerAuth: []
+      summary: Update SMTP configuration
+      tags:
+      - Connections
+    delete:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.SuccessResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete SMTP configuration
+      tags:
+      - Connections
+  /api/portal/connections/templates/{action}:
+    get:
+      parameters:
+      - description: action
+        in: path
+        name: action
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/entities.EmailTemplate'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/response.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Get email template by action
+      tags:
+      - Connections
+    put:
+      consumes:
+      - application/json
+      parameters:
+      - description: action
+        in: path
+        name: action
+        required: true
+        type: string
+      - description: template
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/dto.EmailTemplateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.SuccessResponse'
+      security:
+      - BearerAuth: []
+      summary: Update email template
+      tags:
+      - Connections
   /api/portal/users:
     get:
       description: Retrieve all portal users

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1276,6 +1276,7 @@ definitions:
         type: string
       body:
         type: string
+        description: HTML content template
     required:
     - subject
     - body

--- a/internal/domains/openvpn/usecases/user_usecase.go
+++ b/internal/domains/openvpn/usecases/user_usecase.go
@@ -24,4 +24,5 @@ type UserUsecase interface {
 	// Expiration operations
 	GetExpiringUsers(ctx context.Context, days int) ([]string, error)
 	GetUserExpirations(ctx context.Context, days int) (*openvpndto.UserExpirationsResponse, error)
+	NotifyExpiringUsers(ctx context.Context) error
 }

--- a/internal/domains/openvpn/usecases/user_usecase_impl.go
+++ b/internal/domains/openvpn/usecases/user_usecase_impl.go
@@ -119,7 +119,12 @@ func (u *userUsecaseImpl) CreateUser(ctx context.Context, user *entities.User) e
 
 	if u.emailSvc != nil && user.Email != "" {
 		action := "create_user_" + user.AuthMethod
-		data := map[string]interface{}{"Username": user.Username}
+		data := map[string]interface{}{
+			"Username":      user.Username,
+			"AccessControl": strings.Join(user.AccessControl, ", "),
+			"MACAddress":    strings.Join(user.MacAddresses, ", "),
+			"Expiration":    user.UserExpiration,
+		}
 		if user.IsLocalAuth() {
 			data["Password"] = user.Password
 		}

--- a/internal/domains/openvpn/usecases/user_usecase_impl.go
+++ b/internal/domains/openvpn/usecases/user_usecase_impl.go
@@ -652,6 +652,14 @@ func (u *userUsecaseImpl) ChangePassword(ctx context.Context, username, password
 	}
 
 	logger.Log.WithField("username", username).Info("Password changed successfully")
+
+	if u.emailSvc != nil && user.Email != "" {
+		data := map[string]interface{}{"Username": username}
+		if err := u.emailSvc.Send(ctx, "change_password", user.Email, data); err != nil {
+			logger.Log.WithError(err).Warn("failed to send change password email")
+		}
+	}
+
 	return nil
 }
 
@@ -664,7 +672,7 @@ func (u *userUsecaseImpl) RegenerateTOTP(ctx context.Context, username string) e
 	}
 
 	// Check if user exists
-	_, err := u.userRepo.GetByUsername(ctx, username)
+	user, err := u.userRepo.GetByUsername(ctx, username)
 	if err != nil {
 		return err
 	}
@@ -674,6 +682,13 @@ func (u *userUsecaseImpl) RegenerateTOTP(ctx context.Context, username string) e
 	}
 
 	logger.Log.WithField("username", username).Info("TOTP regenerated successfully")
+
+	if u.emailSvc != nil && user.Email != "" {
+		data := map[string]interface{}{"Username": username}
+		if err := u.emailSvc.Send(ctx, "reset_otp", user.Email, data); err != nil {
+			logger.Log.WithError(err).Warn("failed to send OTP reset email")
+		}
+	}
 	return nil
 }
 

--- a/internal/domains/portal/dto/config_dto.go
+++ b/internal/domains/portal/dto/config_dto.go
@@ -16,3 +16,19 @@ type LDAPConfigRequest struct {
 	BindPassword string `json:"bindPassword" binding:"required"`
 	BaseDN       string `json:"baseDN" binding:"required"`
 }
+
+// SMTPConfigRequest represents payload to set SMTP connection details
+type SMTPConfigRequest struct {
+	Host     string `json:"host" binding:"required"`
+	Port     int    `json:"port" binding:"required"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	From     string `json:"from" binding:"required"`
+	TLS      bool   `json:"tls"`
+}
+
+// EmailTemplateRequest represents payload to set email template
+type EmailTemplateRequest struct {
+	Subject string `json:"subject" binding:"required"`
+	Body    string `json:"body" binding:"required"`
+}

--- a/internal/domains/portal/entities/email_template.go
+++ b/internal/domains/portal/entities/email_template.go
@@ -1,0 +1,17 @@
+package entities
+
+import (
+	"github.com/google/uuid"
+	"time"
+)
+
+// EmailTemplate stores customizable email templates for various actions
+// Action is a unique identifier like "create_user" or "expiration"
+type EmailTemplate struct {
+	ID        uuid.UUID
+	Action    string
+	Subject   string
+	Body      string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}

--- a/internal/domains/portal/entities/smtp_config.go
+++ b/internal/domains/portal/entities/smtp_config.go
@@ -1,0 +1,19 @@
+package entities
+
+import (
+	"github.com/google/uuid"
+	"time"
+)
+
+// SMTPConfig holds SMTP server configuration stored in the database
+type SMTPConfig struct {
+	ID        uuid.UUID
+	Host      string
+	Port      int
+	Username  string
+	Password  string
+	From      string
+	TLS       bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}

--- a/internal/domains/portal/handlers/audit_handler.go
+++ b/internal/domains/portal/handlers/audit_handler.go
@@ -20,6 +20,7 @@ func NewAuditHandler(u usecases.AuditUsecase) *AuditHandler { return &AuditHandl
 
 // GetAuditLogs godoc
 // @Summary List audit logs
+// @Description Retrieve audit logs with filtering and pagination
 // @Tags Audit
 // @Security BearerAuth
 // @Produce json
@@ -31,6 +32,8 @@ func NewAuditHandler(u usecases.AuditUsecase) *AuditHandler { return &AuditHandl
 // @Param page query int false "Page number" default(1)
 // @Param limit query int false "Items per page" default(20)
 // @Success 200 {object} response.SuccessResponse{data=[]entities.AuditLog}
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/audit/logs [get]
 type auditQuery struct {
 	Username string     `form:"username"`
@@ -62,6 +65,7 @@ func (h *AuditHandler) GetAuditLogs(c *gin.Context) {
 
 // ExportAuditLogs godoc
 // @Summary Export audit logs
+// @Description Export audit logs as CSV file
 // @Tags Audit
 // @Security BearerAuth
 // @Produce text/csv
@@ -71,6 +75,8 @@ func (h *AuditHandler) GetAuditLogs(c *gin.Context) {
 // @Param from query string false "Start date" Format(date)
 // @Param to query string false "End date" Format(date)
 // @Success 200 {string} string "CSV file"
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/audit/logs/export [get]
 func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 	var q auditQuery
@@ -109,6 +115,7 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 
 // GetAuditStats godoc
 // @Summary Audit statistics
+// @Description Statistics summary of audit logs
 // @Tags Audit
 // @Security BearerAuth
 // @Produce json
@@ -118,6 +125,8 @@ func (h *AuditHandler) ExportAuditLogs(c *gin.Context) {
 // @Param from query string false "Start date" Format(date)
 // @Param to query string false "End date" Format(date)
 // @Success 200 {object} response.SuccessResponse{data=map[string]int}
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/audit/stats [get]
 func (h *AuditHandler) GetAuditStats(c *gin.Context) {
 	var q auditQuery

--- a/internal/domains/portal/handlers/config_handler.go
+++ b/internal/domains/portal/handlers/config_handler.go
@@ -6,6 +6,7 @@ import (
 	"system-portal/internal/domains/portal/dto"
 	"system-portal/internal/domains/portal/entities"
 	"system-portal/internal/domains/portal/usecases"
+	"system-portal/internal/shared/errors"
 	httpresp "system-portal/internal/shared/response"
 )
 
@@ -29,11 +30,11 @@ func NewConfigHandler(u usecases.ConfigUsecase, reload func()) *ConfigHandler {
 func (h *ConfigHandler) GetOpenVPNConfig(c *gin.Context) {
 	cfg, err := h.uc.GetOpenVPN(c.Request.Context())
 	if err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	if cfg == nil {
-		httpresp.RespondWithNotFound(c, "not found")
+		httpresp.RespondWithError(c, errors.NotFound("not found", nil))
 		return
 	}
 	httpresp.RespondWithSuccess(c, nethttp.StatusOK, cfg)
@@ -52,12 +53,12 @@ func (h *ConfigHandler) GetOpenVPNConfig(c *gin.Context) {
 func (h *ConfigHandler) TestOpenVPN(c *gin.Context) {
 	var req dto.OpenVPNConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		httpresp.RespondWithBadRequest(c, "invalid request")
+		httpresp.RespondWithError(c, errors.BadRequest("invalid request", nil))
 		return
 	}
 	cfg := &entities.OpenVPNConfig{Host: req.Host, Username: req.Username, Password: req.Password, Port: req.Port}
 	if err := h.uc.TestOpenVPN(c.Request.Context(), cfg); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	httpresp.RespondWithMessage(c, nethttp.StatusOK, "ok")
@@ -75,16 +76,16 @@ func (h *ConfigHandler) TestOpenVPN(c *gin.Context) {
 func (h *ConfigHandler) CreateOpenVPNConfig(c *gin.Context) {
 	var req dto.OpenVPNConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		httpresp.RespondWithBadRequest(c, "invalid request")
+		httpresp.RespondWithError(c, errors.BadRequest("invalid request", nil))
 		return
 	}
 
 	// ensure only one configuration exists
 	if existing, err := h.uc.GetOpenVPN(c.Request.Context()); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	} else if existing != nil {
-		httpresp.RespondWithBadRequest(c, "configuration already exists")
+		httpresp.RespondWithError(c, errors.Conflict("configuration already exists", nil))
 		return
 	}
 
@@ -95,7 +96,7 @@ func (h *ConfigHandler) CreateOpenVPNConfig(c *gin.Context) {
 		Port:     req.Port,
 	}
 	if err := h.uc.SetOpenVPN(c.Request.Context(), cfg); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	if h.reload != nil {
@@ -116,16 +117,16 @@ func (h *ConfigHandler) CreateOpenVPNConfig(c *gin.Context) {
 func (h *ConfigHandler) UpdateOpenVPNConfig(c *gin.Context) {
 	var req dto.OpenVPNConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		httpresp.RespondWithBadRequest(c, "invalid request")
+		httpresp.RespondWithError(c, errors.BadRequest("invalid request", nil))
 		return
 	}
 
 	// ensure configuration exists before updating
 	if existing, err := h.uc.GetOpenVPN(c.Request.Context()); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	} else if existing == nil {
-		httpresp.RespondWithNotFound(c, "not found")
+		httpresp.RespondWithError(c, errors.NotFound("not found", nil))
 		return
 	}
 
@@ -136,7 +137,7 @@ func (h *ConfigHandler) UpdateOpenVPNConfig(c *gin.Context) {
 		Port:     req.Port,
 	}
 	if err := h.uc.SetOpenVPN(c.Request.Context(), cfg); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	if h.reload != nil {
@@ -154,7 +155,7 @@ func (h *ConfigHandler) UpdateOpenVPNConfig(c *gin.Context) {
 // @Router /api/portal/connections/openvpn [delete]
 func (h *ConfigHandler) DeleteOpenVPNConfig(c *gin.Context) {
 	if err := h.uc.DeleteOpenVPN(c.Request.Context()); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	if h.reload != nil {
@@ -174,11 +175,11 @@ func (h *ConfigHandler) DeleteOpenVPNConfig(c *gin.Context) {
 func (h *ConfigHandler) GetLDAPConfig(c *gin.Context) {
 	cfg, err := h.uc.GetLDAP(c.Request.Context())
 	if err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	if cfg == nil {
-		httpresp.RespondWithNotFound(c, "not found")
+		httpresp.RespondWithError(c, errors.NotFound("not found", nil))
 		return
 	}
 	httpresp.RespondWithSuccess(c, nethttp.StatusOK, cfg)
@@ -197,12 +198,12 @@ func (h *ConfigHandler) GetLDAPConfig(c *gin.Context) {
 func (h *ConfigHandler) TestLDAP(c *gin.Context) {
 	var req dto.LDAPConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		httpresp.RespondWithBadRequest(c, "invalid request")
+		httpresp.RespondWithError(c, errors.BadRequest("invalid request", nil))
 		return
 	}
 	cfg := &entities.LDAPConfig{Host: req.Host, Port: req.Port, BindDN: req.BindDN, BindPassword: req.BindPassword, BaseDN: req.BaseDN}
 	if err := h.uc.TestLDAP(c.Request.Context(), cfg); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	httpresp.RespondWithMessage(c, nethttp.StatusOK, "ok")
@@ -220,16 +221,16 @@ func (h *ConfigHandler) TestLDAP(c *gin.Context) {
 func (h *ConfigHandler) CreateLDAPConfig(c *gin.Context) {
 	var req dto.LDAPConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		httpresp.RespondWithBadRequest(c, "invalid request")
+		httpresp.RespondWithError(c, errors.BadRequest("invalid request", nil))
 		return
 	}
 
 	// ensure only one configuration exists
 	if existing, err := h.uc.GetLDAP(c.Request.Context()); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	} else if existing != nil {
-		httpresp.RespondWithBadRequest(c, "configuration already exists")
+		httpresp.RespondWithError(c, errors.Conflict("configuration already exists", nil))
 		return
 	}
 
@@ -241,7 +242,7 @@ func (h *ConfigHandler) CreateLDAPConfig(c *gin.Context) {
 		BaseDN:       req.BaseDN,
 	}
 	if err := h.uc.SetLDAP(c.Request.Context(), cfg); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	if h.reload != nil {
@@ -262,16 +263,16 @@ func (h *ConfigHandler) CreateLDAPConfig(c *gin.Context) {
 func (h *ConfigHandler) UpdateLDAPConfig(c *gin.Context) {
 	var req dto.LDAPConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		httpresp.RespondWithBadRequest(c, "invalid request")
+		httpresp.RespondWithError(c, errors.BadRequest("invalid request", nil))
 		return
 	}
 
 	// ensure configuration exists before updating
 	if existing, err := h.uc.GetLDAP(c.Request.Context()); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	} else if existing == nil {
-		httpresp.RespondWithNotFound(c, "not found")
+		httpresp.RespondWithError(c, errors.NotFound("not found", nil))
 		return
 	}
 
@@ -283,7 +284,7 @@ func (h *ConfigHandler) UpdateLDAPConfig(c *gin.Context) {
 		BaseDN:       req.BaseDN,
 	}
 	if err := h.uc.SetLDAP(c.Request.Context(), cfg); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	if h.reload != nil {
@@ -301,7 +302,7 @@ func (h *ConfigHandler) UpdateLDAPConfig(c *gin.Context) {
 // @Router /api/portal/connections/ldap [delete]
 func (h *ConfigHandler) DeleteLDAPConfig(c *gin.Context) {
 	if err := h.uc.DeleteLDAP(c.Request.Context()); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	if h.reload != nil {
@@ -321,11 +322,11 @@ func (h *ConfigHandler) DeleteLDAPConfig(c *gin.Context) {
 func (h *ConfigHandler) GetSMTPConfig(c *gin.Context) {
 	cfg, err := h.uc.GetSMTP(c.Request.Context())
 	if err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	if cfg == nil {
-		httpresp.RespondWithNotFound(c, "not found")
+		httpresp.RespondWithError(c, errors.NotFound("not found", nil))
 		return
 	}
 	httpresp.RespondWithSuccess(c, nethttp.StatusOK, cfg)
@@ -343,19 +344,19 @@ func (h *ConfigHandler) GetSMTPConfig(c *gin.Context) {
 func (h *ConfigHandler) CreateSMTPConfig(c *gin.Context) {
 	var req dto.SMTPConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		httpresp.RespondWithBadRequest(c, "invalid request")
+		httpresp.RespondWithError(c, errors.BadRequest("invalid request", nil))
 		return
 	}
 	if existing, err := h.uc.GetSMTP(c.Request.Context()); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	} else if existing != nil {
-		httpresp.RespondWithBadRequest(c, "configuration already exists")
+		httpresp.RespondWithError(c, errors.Conflict("configuration already exists", nil))
 		return
 	}
 	cfg := &entities.SMTPConfig{Host: req.Host, Port: req.Port, Username: req.Username, Password: req.Password, From: req.From, TLS: req.TLS}
 	if err := h.uc.SetSMTP(c.Request.Context(), cfg); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	httpresp.RespondWithMessage(c, nethttp.StatusCreated, "saved")
@@ -373,19 +374,19 @@ func (h *ConfigHandler) CreateSMTPConfig(c *gin.Context) {
 func (h *ConfigHandler) UpdateSMTPConfig(c *gin.Context) {
 	var req dto.SMTPConfigRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		httpresp.RespondWithBadRequest(c, "invalid request")
+		httpresp.RespondWithError(c, errors.BadRequest("invalid request", nil))
 		return
 	}
 	if existing, err := h.uc.GetSMTP(c.Request.Context()); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	} else if existing == nil {
-		httpresp.RespondWithNotFound(c, "not found")
+		httpresp.RespondWithError(c, errors.NotFound("not found", nil))
 		return
 	}
 	cfg := &entities.SMTPConfig{Host: req.Host, Port: req.Port, Username: req.Username, Password: req.Password, From: req.From, TLS: req.TLS}
 	if err := h.uc.SetSMTP(c.Request.Context(), cfg); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	httpresp.RespondWithMessage(c, nethttp.StatusOK, "saved")
@@ -400,7 +401,7 @@ func (h *ConfigHandler) UpdateSMTPConfig(c *gin.Context) {
 // @Router /api/portal/connections/smtp [delete]
 func (h *ConfigHandler) DeleteSMTPConfig(c *gin.Context) {
 	if err := h.uc.DeleteSMTP(c.Request.Context()); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	httpresp.RespondWithMessage(c, nethttp.StatusOK, "deleted")
@@ -419,11 +420,11 @@ func (h *ConfigHandler) GetEmailTemplate(c *gin.Context) {
 	action := c.Param("action")
 	tpl, err := h.uc.GetTemplate(c.Request.Context(), action)
 	if err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	if tpl == nil {
-		httpresp.RespondWithNotFound(c, "not found")
+		httpresp.RespondWithError(c, errors.NotFound("not found", nil))
 		return
 	}
 	httpresp.RespondWithSuccess(c, nethttp.StatusOK, tpl)
@@ -443,12 +444,12 @@ func (h *ConfigHandler) UpdateEmailTemplate(c *gin.Context) {
 	action := c.Param("action")
 	var req dto.EmailTemplateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		httpresp.RespondWithBadRequest(c, "invalid request")
+		httpresp.RespondWithError(c, errors.BadRequest("invalid request", nil))
 		return
 	}
 	tpl := &entities.EmailTemplate{Action: action, Subject: req.Subject, Body: req.Body}
 	if err := h.uc.SetTemplate(c.Request.Context(), tpl); err != nil {
-		httpresp.RespondWithBadRequest(c, err.Error())
+		httpresp.RespondWithError(c, errors.BadRequest(err.Error(), err))
 		return
 	}
 	httpresp.RespondWithMessage(c, nethttp.StatusOK, "saved")

--- a/internal/domains/portal/handlers/config_handler.go
+++ b/internal/domains/portal/handlers/config_handler.go
@@ -21,11 +21,14 @@ func NewConfigHandler(u usecases.ConfigUsecase, reload func()) *ConfigHandler {
 
 // GetOpenVPNConfig godoc
 // @Summary Get OpenVPN connection
+// @Description Retrieve OpenVPN connection settings
 // @Tags Connections
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse{data=entities.OpenVPNConfig}
 // @Failure 404 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/openvpn [get]
 func (h *ConfigHandler) GetOpenVPNConfig(c *gin.Context) {
 	cfg, err := h.uc.GetOpenVPN(c.Request.Context())
@@ -42,6 +45,7 @@ func (h *ConfigHandler) GetOpenVPNConfig(c *gin.Context) {
 
 // TestOpenVPN godoc
 // @Summary Test OpenVPN connection
+// @Description Test connectivity to the OpenVPN server
 // @Tags Connections
 // @Security BearerAuth
 // @Accept json
@@ -49,6 +53,8 @@ func (h *ConfigHandler) GetOpenVPNConfig(c *gin.Context) {
 // @Param request body dto.OpenVPNConfigRequest true "OpenVPN config"
 // @Success 200 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/openvpn/test [post]
 func (h *ConfigHandler) TestOpenVPN(c *gin.Context) {
 	var req dto.OpenVPNConfigRequest
@@ -66,12 +72,17 @@ func (h *ConfigHandler) TestOpenVPN(c *gin.Context) {
 
 // CreateOpenVPNConfig godoc
 // @Summary Create OpenVPN connection
+// @Description Create OpenVPN connection settings
 // @Tags Connections
 // @Security BearerAuth
 // @Accept json
 // @Produce json
 // @Param request body dto.OpenVPNConfigRequest true "OpenVPN config"
 // @Success 201 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 409 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/openvpn [post]
 func (h *ConfigHandler) CreateOpenVPNConfig(c *gin.Context) {
 	var req dto.OpenVPNConfigRequest
@@ -107,12 +118,17 @@ func (h *ConfigHandler) CreateOpenVPNConfig(c *gin.Context) {
 
 // UpdateOpenVPNConfig godoc
 // @Summary Update OpenVPN connection
+// @Description Update existing OpenVPN connection settings
 // @Tags Connections
 // @Security BearerAuth
 // @Accept json
 // @Produce json
 // @Param request body dto.OpenVPNConfigRequest true "OpenVPN config"
 // @Success 200 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/openvpn [put]
 func (h *ConfigHandler) UpdateOpenVPNConfig(c *gin.Context) {
 	var req dto.OpenVPNConfigRequest
@@ -148,10 +164,13 @@ func (h *ConfigHandler) UpdateOpenVPNConfig(c *gin.Context) {
 
 // DeleteOpenVPNConfig godoc
 // @Summary Delete OpenVPN connection
+// @Description Remove OpenVPN connection settings
 // @Tags Connections
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/openvpn [delete]
 func (h *ConfigHandler) DeleteOpenVPNConfig(c *gin.Context) {
 	if err := h.uc.DeleteOpenVPN(c.Request.Context()); err != nil {
@@ -166,11 +185,14 @@ func (h *ConfigHandler) DeleteOpenVPNConfig(c *gin.Context) {
 
 // GetLDAPConfig godoc
 // @Summary Get LDAP connection
+// @Description Retrieve LDAP connection settings
 // @Tags Connections
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse{data=entities.LDAPConfig}
 // @Failure 404 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/ldap [get]
 func (h *ConfigHandler) GetLDAPConfig(c *gin.Context) {
 	cfg, err := h.uc.GetLDAP(c.Request.Context())
@@ -187,6 +209,7 @@ func (h *ConfigHandler) GetLDAPConfig(c *gin.Context) {
 
 // TestLDAP godoc
 // @Summary Test LDAP connection
+// @Description Test connectivity to the LDAP server
 // @Tags Connections
 // @Security BearerAuth
 // @Accept json
@@ -194,6 +217,8 @@ func (h *ConfigHandler) GetLDAPConfig(c *gin.Context) {
 // @Param request body dto.LDAPConfigRequest true "LDAP config"
 // @Success 200 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/ldap/test [post]
 func (h *ConfigHandler) TestLDAP(c *gin.Context) {
 	var req dto.LDAPConfigRequest
@@ -211,12 +236,17 @@ func (h *ConfigHandler) TestLDAP(c *gin.Context) {
 
 // CreateLDAPConfig godoc
 // @Summary Create LDAP connection
+// @Description Create LDAP connection settings
 // @Tags Connections
 // @Security BearerAuth
 // @Accept json
 // @Produce json
 // @Param request body dto.LDAPConfigRequest true "LDAP config"
 // @Success 201 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 409 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/ldap [post]
 func (h *ConfigHandler) CreateLDAPConfig(c *gin.Context) {
 	var req dto.LDAPConfigRequest
@@ -253,12 +283,17 @@ func (h *ConfigHandler) CreateLDAPConfig(c *gin.Context) {
 
 // UpdateLDAPConfig godoc
 // @Summary Update LDAP connection
+// @Description Update existing LDAP connection settings
 // @Tags Connections
 // @Security BearerAuth
 // @Accept json
 // @Produce json
 // @Param request body dto.LDAPConfigRequest true "LDAP config"
 // @Success 200 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/ldap [put]
 func (h *ConfigHandler) UpdateLDAPConfig(c *gin.Context) {
 	var req dto.LDAPConfigRequest
@@ -295,10 +330,13 @@ func (h *ConfigHandler) UpdateLDAPConfig(c *gin.Context) {
 
 // DeleteLDAPConfig godoc
 // @Summary Delete LDAP connection
+// @Description Remove LDAP connection settings
 // @Tags Connections
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/ldap [delete]
 func (h *ConfigHandler) DeleteLDAPConfig(c *gin.Context) {
 	if err := h.uc.DeleteLDAP(c.Request.Context()); err != nil {
@@ -313,11 +351,14 @@ func (h *ConfigHandler) DeleteLDAPConfig(c *gin.Context) {
 
 // GetSMTPConfig godoc
 // @Summary Get SMTP configuration
+// @Description Retrieve SMTP server settings
 // @Tags Connections
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse{data=entities.SMTPConfig}
 // @Failure 404 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/smtp [get]
 func (h *ConfigHandler) GetSMTPConfig(c *gin.Context) {
 	cfg, err := h.uc.GetSMTP(c.Request.Context())
@@ -334,12 +375,17 @@ func (h *ConfigHandler) GetSMTPConfig(c *gin.Context) {
 
 // CreateSMTPConfig godoc
 // @Summary Create SMTP configuration
+// @Description Create SMTP server configuration in database
 // @Tags Connections
 // @Security BearerAuth
 // @Accept json
 // @Produce json
 // @Param request body dto.SMTPConfigRequest true "SMTP config"
 // @Success 201 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 409 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/smtp [post]
 func (h *ConfigHandler) CreateSMTPConfig(c *gin.Context) {
 	var req dto.SMTPConfigRequest
@@ -364,12 +410,17 @@ func (h *ConfigHandler) CreateSMTPConfig(c *gin.Context) {
 
 // UpdateSMTPConfig godoc
 // @Summary Update SMTP configuration
+// @Description Update SMTP server configuration
 // @Tags Connections
 // @Security BearerAuth
 // @Accept json
 // @Produce json
 // @Param request body dto.SMTPConfigRequest true "SMTP config"
 // @Success 200 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/smtp [put]
 func (h *ConfigHandler) UpdateSMTPConfig(c *gin.Context) {
 	var req dto.SMTPConfigRequest
@@ -394,10 +445,13 @@ func (h *ConfigHandler) UpdateSMTPConfig(c *gin.Context) {
 
 // DeleteSMTPConfig godoc
 // @Summary Delete SMTP configuration
+// @Description Remove SMTP configuration from database
 // @Tags Connections
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/smtp [delete]
 func (h *ConfigHandler) DeleteSMTPConfig(c *gin.Context) {
 	if err := h.uc.DeleteSMTP(c.Request.Context()); err != nil {
@@ -409,12 +463,15 @@ func (h *ConfigHandler) DeleteSMTPConfig(c *gin.Context) {
 
 // GetEmailTemplate godoc
 // @Summary Get email template by action
+// @Description Retrieve an email template for the given action
 // @Tags Connections
 // @Security BearerAuth
 // @Produce json
 // @Param action path string true "action"
 // @Success 200 {object} response.SuccessResponse{data=entities.EmailTemplate}
 // @Failure 404 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/templates/{action} [get]
 func (h *ConfigHandler) GetEmailTemplate(c *gin.Context) {
 	action := c.Param("action")
@@ -432,6 +489,7 @@ func (h *ConfigHandler) GetEmailTemplate(c *gin.Context) {
 
 // UpdateEmailTemplate godoc
 // @Summary Update email template
+// @Description Update subject or body of a template
 // @Tags Connections
 // @Security BearerAuth
 // @Accept json
@@ -439,6 +497,9 @@ func (h *ConfigHandler) GetEmailTemplate(c *gin.Context) {
 // @Param action path string true "action"
 // @Param request body dto.EmailTemplateRequest true "template"
 // @Success 200 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/connections/templates/{action} [put]
 func (h *ConfigHandler) UpdateEmailTemplate(c *gin.Context) {
 	action := c.Param("action")

--- a/internal/domains/portal/handlers/config_handler.go
+++ b/internal/domains/portal/handlers/config_handler.go
@@ -309,3 +309,147 @@ func (h *ConfigHandler) DeleteLDAPConfig(c *gin.Context) {
 	}
 	httpresp.RespondWithMessage(c, nethttp.StatusOK, "deleted")
 }
+
+// GetSMTPConfig godoc
+// @Summary Get SMTP configuration
+// @Tags Connections
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {object} response.SuccessResponse{data=entities.SMTPConfig}
+// @Failure 404 {object} response.ErrorResponse
+// @Router /api/portal/connections/smtp [get]
+func (h *ConfigHandler) GetSMTPConfig(c *gin.Context) {
+	cfg, err := h.uc.GetSMTP(c.Request.Context())
+	if err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	if cfg == nil {
+		httpresp.RespondWithNotFound(c, "not found")
+		return
+	}
+	httpresp.RespondWithSuccess(c, nethttp.StatusOK, cfg)
+}
+
+// CreateSMTPConfig godoc
+// @Summary Create SMTP configuration
+// @Tags Connections
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param request body dto.SMTPConfigRequest true "SMTP config"
+// @Success 201 {object} response.SuccessResponse
+// @Router /api/portal/connections/smtp [post]
+func (h *ConfigHandler) CreateSMTPConfig(c *gin.Context) {
+	var req dto.SMTPConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpresp.RespondWithBadRequest(c, "invalid request")
+		return
+	}
+	if existing, err := h.uc.GetSMTP(c.Request.Context()); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	} else if existing != nil {
+		httpresp.RespondWithBadRequest(c, "configuration already exists")
+		return
+	}
+	cfg := &entities.SMTPConfig{Host: req.Host, Port: req.Port, Username: req.Username, Password: req.Password, From: req.From, TLS: req.TLS}
+	if err := h.uc.SetSMTP(c.Request.Context(), cfg); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	httpresp.RespondWithMessage(c, nethttp.StatusCreated, "saved")
+}
+
+// UpdateSMTPConfig godoc
+// @Summary Update SMTP configuration
+// @Tags Connections
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param request body dto.SMTPConfigRequest true "SMTP config"
+// @Success 200 {object} response.SuccessResponse
+// @Router /api/portal/connections/smtp [put]
+func (h *ConfigHandler) UpdateSMTPConfig(c *gin.Context) {
+	var req dto.SMTPConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpresp.RespondWithBadRequest(c, "invalid request")
+		return
+	}
+	if existing, err := h.uc.GetSMTP(c.Request.Context()); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	} else if existing == nil {
+		httpresp.RespondWithNotFound(c, "not found")
+		return
+	}
+	cfg := &entities.SMTPConfig{Host: req.Host, Port: req.Port, Username: req.Username, Password: req.Password, From: req.From, TLS: req.TLS}
+	if err := h.uc.SetSMTP(c.Request.Context(), cfg); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	httpresp.RespondWithMessage(c, nethttp.StatusOK, "saved")
+}
+
+// DeleteSMTPConfig godoc
+// @Summary Delete SMTP configuration
+// @Tags Connections
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {object} response.SuccessResponse
+// @Router /api/portal/connections/smtp [delete]
+func (h *ConfigHandler) DeleteSMTPConfig(c *gin.Context) {
+	if err := h.uc.DeleteSMTP(c.Request.Context()); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	httpresp.RespondWithMessage(c, nethttp.StatusOK, "deleted")
+}
+
+// GetEmailTemplate godoc
+// @Summary Get email template by action
+// @Tags Connections
+// @Security BearerAuth
+// @Produce json
+// @Param action path string true "action"
+// @Success 200 {object} response.SuccessResponse{data=entities.EmailTemplate}
+// @Failure 404 {object} response.ErrorResponse
+// @Router /api/portal/connections/templates/{action} [get]
+func (h *ConfigHandler) GetEmailTemplate(c *gin.Context) {
+	action := c.Param("action")
+	tpl, err := h.uc.GetTemplate(c.Request.Context(), action)
+	if err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	if tpl == nil {
+		httpresp.RespondWithNotFound(c, "not found")
+		return
+	}
+	httpresp.RespondWithSuccess(c, nethttp.StatusOK, tpl)
+}
+
+// UpdateEmailTemplate godoc
+// @Summary Update email template
+// @Tags Connections
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param action path string true "action"
+// @Param request body dto.EmailTemplateRequest true "template"
+// @Success 200 {object} response.SuccessResponse
+// @Router /api/portal/connections/templates/{action} [put]
+func (h *ConfigHandler) UpdateEmailTemplate(c *gin.Context) {
+	action := c.Param("action")
+	var req dto.EmailTemplateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httpresp.RespondWithBadRequest(c, "invalid request")
+		return
+	}
+	tpl := &entities.EmailTemplate{Action: action, Subject: req.Subject, Body: req.Body}
+	if err := h.uc.SetTemplate(c.Request.Context(), tpl); err != nil {
+		httpresp.RespondWithBadRequest(c, err.Error())
+		return
+	}
+	httpresp.RespondWithMessage(c, nethttp.StatusOK, "saved")
+}

--- a/internal/domains/portal/handlers/dashboard_handler.go
+++ b/internal/domains/portal/handlers/dashboard_handler.go
@@ -19,10 +19,13 @@ func NewDashboardHandler(u repositories.UserRepository, a repositories.AuditRepo
 
 // GetDashboardStats godoc
 // @Summary Dashboard statistics
+// @Description Overall portal statistics
 // @Tags Dashboard
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse{data=dto.StatsResponse}
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/dashboard/stats [get]
 func (h *DashboardHandler) GetDashboardStats(c *gin.Context) {
 	users, total, _ := h.userRepo.List(c.Request.Context(), &entities.UserFilter{})
@@ -34,10 +37,13 @@ func (h *DashboardHandler) GetDashboardStats(c *gin.Context) {
 
 // GetRecentActivities godoc
 // @Summary Recent activities
+// @Description Latest portal activities
 // @Tags Dashboard
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse{data=[]dto.AuditResponse}
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/dashboard/activities [get]
 func (h *DashboardHandler) GetRecentActivities(c *gin.Context) {
 	filter := &entities.AuditFilter{Page: 1, Limit: 10}
@@ -58,10 +64,13 @@ func (h *DashboardHandler) GetRecentActivities(c *gin.Context) {
 
 // GetUserChartData godoc
 // @Summary User chart data
+// @Description Chart statistics of user registrations
 // @Tags Dashboard
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse{data=map[string]interface{}}
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/dashboard/charts/users [get]
 func (h *DashboardHandler) GetUserChartData(c *gin.Context) {
 	http.RespondWithSuccess(c, 200, gin.H{})
@@ -69,10 +78,13 @@ func (h *DashboardHandler) GetUserChartData(c *gin.Context) {
 
 // GetActivityChartData godoc
 // @Summary Activity chart data
+// @Description Chart statistics of portal activities
 // @Tags Dashboard
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse{data=map[string]interface{}}
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/dashboard/charts/activities [get]
 func (h *DashboardHandler) GetActivityChartData(c *gin.Context) {
 	http.RespondWithSuccess(c, 200, gin.H{})

--- a/internal/domains/portal/handlers/group_handler.go
+++ b/internal/domains/portal/handlers/group_handler.go
@@ -17,10 +17,13 @@ func NewGroupHandler(u usecases.GroupUsecase) *GroupHandler { return &GroupHandl
 
 // ListGroups godoc
 // @Summary List portal groups
+// @Description Retrieve portal groups with pagination
 // @Tags Portal Groups
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse{data=[]entities.PortalGroup}
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/groups [get]
 type groupQuery struct {
 	Name  string `form:"name"`
@@ -38,6 +41,7 @@ func (h *GroupHandler) ListGroups(c *gin.Context) {
 
 // GetGroup godoc
 // @Summary Get portal group
+// @Description Get portal group by ID
 // @Tags Portal Groups
 // @Security BearerAuth
 // @Produce json
@@ -45,6 +49,8 @@ func (h *GroupHandler) ListGroups(c *gin.Context) {
 // @Success 200 {object} response.SuccessResponse{data=entities.PortalGroup}
 // @Failure 400 {object} response.ErrorResponse
 // @Failure 404 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/groups/{id} [get]
 func (h *GroupHandler) GetGroup(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
@@ -62,6 +68,7 @@ func (h *GroupHandler) GetGroup(c *gin.Context) {
 
 // CreateGroup godoc
 // @Summary Create portal group
+// @Description Create a new portal group
 // @Tags Portal Groups
 // @Security BearerAuth
 // @Accept json
@@ -69,6 +76,8 @@ func (h *GroupHandler) GetGroup(c *gin.Context) {
 // @Param request body entities.PortalGroup true "Group data"
 // @Success 201 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/groups [post]
 func (h *GroupHandler) CreateGroup(c *gin.Context) {
 	var g entities.PortalGroup
@@ -88,6 +97,7 @@ func (h *GroupHandler) CreateGroup(c *gin.Context) {
 
 // UpdateGroup godoc
 // @Summary Update portal group
+// @Description Update information for a portal group
 // @Tags Portal Groups
 // @Security BearerAuth
 // @Accept json
@@ -96,6 +106,9 @@ func (h *GroupHandler) CreateGroup(c *gin.Context) {
 // @Param request body entities.PortalGroup true "Group data"
 // @Success 200 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/groups/{id} [put]
 func (h *GroupHandler) UpdateGroup(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
@@ -119,12 +132,16 @@ func (h *GroupHandler) UpdateGroup(c *gin.Context) {
 
 // DeleteGroup godoc
 // @Summary Delete portal group
+// @Description Remove a portal group
 // @Tags Portal Groups
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "Group ID"
 // @Success 200 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/groups/{id} [delete]
 func (h *GroupHandler) DeleteGroup(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
@@ -141,10 +158,13 @@ func (h *GroupHandler) DeleteGroup(c *gin.Context) {
 
 // ListPermissions godoc
 // @Summary List permissions
+// @Description Retrieve all available permissions
 // @Tags Permissions
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse{data=[]*entities.Permission}
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/permissions [get]
 func (h *GroupHandler) ListPermissions(c *gin.Context) {
 	perms, _ := h.uc.ListPermissions(c.Request.Context())
@@ -153,11 +173,15 @@ func (h *GroupHandler) ListPermissions(c *gin.Context) {
 
 // GetGroupPermissions godoc
 // @Summary Get permissions for a group
+// @Description Retrieve permissions assigned to a specific group
 // @Tags Permissions
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "Group ID"
 // @Success 200 {object} response.SuccessResponse{data=[]*entities.Permission}
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/groups/{id}/permissions [get]
 func (h *GroupHandler) GetGroupPermissions(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
@@ -175,6 +199,7 @@ type updatePermsRequest struct {
 
 // UpdateGroupPermissions godoc
 // @Summary Update group permissions
+// @Description Update the set of permissions assigned to a group
 // @Tags Permissions
 // @Security BearerAuth
 // @Accept json
@@ -182,6 +207,10 @@ type updatePermsRequest struct {
 // @Param id path string true "Group ID"
 // @Param request body updatePermsRequest true "Permission IDs"
 // @Success 200 {object} response.SuccessResponse
+// @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/groups/{id}/permissions [put]
 func (h *GroupHandler) UpdateGroupPermissions(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))

--- a/internal/domains/portal/handlers/permission_handler.go
+++ b/internal/domains/portal/handlers/permission_handler.go
@@ -19,10 +19,13 @@ func NewPermissionHandler(u usecases.PermissionUsecase) *PermissionHandler {
 
 // ListPermissions godoc
 // @Summary List permissions
+// @Description Retrieve all permissions
 // @Tags Permissions
 // @Security BearerAuth
 // @Produce json
 // @Success 200 {object} response.SuccessResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/permissions [get]
 func (h *PermissionHandler) ListPermissions(c *gin.Context) {
 	perms, err := h.uc.List(c.Request.Context())
@@ -35,6 +38,7 @@ func (h *PermissionHandler) ListPermissions(c *gin.Context) {
 
 // CreatePermission godoc
 // @Summary Create permission
+// @Description Create a new permission
 // @Tags Permissions
 // @Security BearerAuth
 // @Accept json
@@ -42,6 +46,8 @@ func (h *PermissionHandler) ListPermissions(c *gin.Context) {
 // @Param request body entities.Permission true "Permission data"
 // @Success 201 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/permissions [post]
 func (h *PermissionHandler) CreatePermission(c *gin.Context) {
 	var p entities.Permission
@@ -59,6 +65,7 @@ func (h *PermissionHandler) CreatePermission(c *gin.Context) {
 
 // UpdatePermission godoc
 // @Summary Update permission
+// @Description Update an existing permission
 // @Tags Permissions
 // @Security BearerAuth
 // @Accept json
@@ -67,6 +74,9 @@ func (h *PermissionHandler) CreatePermission(c *gin.Context) {
 // @Param request body entities.Permission true "Permission data"
 // @Success 200 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/permissions/{id} [put]
 func (h *PermissionHandler) UpdatePermission(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
@@ -89,12 +99,16 @@ func (h *PermissionHandler) UpdatePermission(c *gin.Context) {
 
 // DeletePermission godoc
 // @Summary Delete permission
+// @Description Remove a permission by ID
 // @Tags Permissions
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "Permission ID"
 // @Success 200 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/permissions/{id} [delete]
 func (h *PermissionHandler) DeletePermission(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))

--- a/internal/domains/portal/handlers/user_handler.go
+++ b/internal/domains/portal/handlers/user_handler.go
@@ -21,11 +21,18 @@ func NewUserHandler(u usecases.UserUsecase) *UserHandler { return &UserHandler{u
 
 // ListUsers godoc
 // @Summary List portal users
-// @Description Retrieve all portal users
+// @Description Retrieve all portal users with optional filters
 // @Tags Portal Users
 // @Security BearerAuth
 // @Produce json
+// @Param username query string false "Filter by username"
+// @Param email query string false "Filter by email"
+// @Param groupId query string false "Filter by group ID"
+// @Param page query int false "Page number" default(1)
+// @Param limit query int false "Items per page" default(20)
 // @Success 200 {object} response.SuccessResponse{data=[]dto.PortalUserResponse}
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/users [get]
 type userQuery struct {
 	Username string    `form:"username"`
@@ -64,6 +71,8 @@ func (h *UserHandler) ListUsers(c *gin.Context) {
 // @Param request body dto.PortalUserRequest true "User data"
 // @Success 201 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/users [post]
 func (h *UserHandler) CreateUser(c *gin.Context) {
 	var req dto.PortalUserRequest
@@ -99,6 +108,8 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 // @Success 200 {object} response.SuccessResponse{data=dto.PortalUserResponse}
 // @Failure 400 {object} response.ErrorResponse
 // @Failure 404 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/users/{id} [get]
 func (h *UserHandler) GetUser(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
@@ -132,6 +143,9 @@ func (h *UserHandler) GetUser(c *gin.Context) {
 // @Param request body dto.PortalUserRequest true "User data"
 // @Success 200 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/users/{id} [put]
 func (h *UserHandler) UpdateUser(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
@@ -168,6 +182,9 @@ func (h *UserHandler) UpdateUser(c *gin.Context) {
 // @Param id path string true "User ID"
 // @Success 200 {object} response.SuccessResponse
 // @Failure 400 {object} response.ErrorResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/users/{id} [delete]
 func (h *UserHandler) DeleteUser(c *gin.Context) {
 	id, err := uuid.Parse(c.Param("id"))
@@ -184,30 +201,42 @@ func (h *UserHandler) DeleteUser(c *gin.Context) {
 
 // ActivateUser godoc
 // @Summary Activate portal user
+// @Description Activate a portal user account
 // @Tags Portal Users
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "User ID"
 // @Success 200 {object} response.SuccessResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/users/{id}/activate [put]
 func (h *UserHandler) ActivateUser(c *gin.Context) { http.RespondWithMessage(c, 200, "ok") }
 
 // DeactivateUser godoc
 // @Summary Deactivate portal user
+// @Description Disable a portal user account
 // @Tags Portal Users
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "User ID"
 // @Success 200 {object} response.SuccessResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/users/{id}/deactivate [put]
 func (h *UserHandler) DeactivateUser(c *gin.Context) { http.RespondWithMessage(c, 200, "ok") }
 
 // ResetPassword godoc
 // @Summary Reset portal user password
+// @Description Reset the password of a portal user
 // @Tags Portal Users
 // @Security BearerAuth
 // @Produce json
 // @Param id path string true "User ID"
 // @Success 200 {object} response.SuccessResponse
+// @Failure 401 {object} response.ErrorResponse
+// @Failure 404 {object} response.ErrorResponse
+// @Failure 500 {object} response.ErrorResponse
 // @Router /api/portal/users/{id}/reset-password [put]
 func (h *UserHandler) ResetPassword(c *gin.Context) { http.RespondWithMessage(c, 200, "ok") }

--- a/internal/domains/portal/repositories/email_template_repository.go
+++ b/internal/domains/portal/repositories/email_template_repository.go
@@ -1,0 +1,11 @@
+package repositories
+
+import (
+	"context"
+	"system-portal/internal/domains/portal/entities"
+)
+
+type EmailTemplateRepository interface {
+	GetByAction(ctx context.Context, action string) (*entities.EmailTemplate, error)
+	Upsert(ctx context.Context, tpl *entities.EmailTemplate) error
+}

--- a/internal/domains/portal/repositories/impl/audit_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/audit_repository_pg.go
@@ -86,7 +86,8 @@ func (r *pgAuditRepo) List(ctx context.Context, f *entities.AuditFilter) ([]*ent
 	}
 
 	query := base + where + " ORDER BY created_at DESC" +
-		fmt.Sprintf(" LIMIT %d OFFSET %d", f.Limit, f.Offset)
+		fmt.Sprintf(" LIMIT $%d OFFSET $%d", idx, idx+1)
+	args = append(args, f.Limit, f.Offset)
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, 0, err

--- a/internal/domains/portal/repositories/impl/email_template_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/email_template_repository_pg.go
@@ -1,0 +1,36 @@
+package impl
+
+import (
+	"context"
+	"database/sql"
+
+	"system-portal/internal/domains/portal/entities"
+	"system-portal/internal/domains/portal/repositories"
+)
+
+type pgEmailTemplateRepo struct{ db *sql.DB }
+
+func NewEmailTemplateRepositoryPG(db *sql.DB) repositories.EmailTemplateRepository {
+	return &pgEmailTemplateRepo{db: db}
+}
+
+func (r *pgEmailTemplateRepo) GetByAction(ctx context.Context, action string) (*entities.EmailTemplate, error) {
+	row := r.db.QueryRowContext(ctx, `SELECT id, action, subject, body, created_at, updated_at FROM email_templates WHERE action=$1`, action)
+	var tpl entities.EmailTemplate
+	if err := row.Scan(&tpl.ID, &tpl.Action, &tpl.Subject, &tpl.Body, &tpl.CreatedAt, &tpl.UpdatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &tpl, nil
+}
+
+func (r *pgEmailTemplateRepo) Upsert(ctx context.Context, tpl *entities.EmailTemplate) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO email_templates (id, action, subject, body, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$5)
+        ON CONFLICT (action) DO UPDATE SET subject=EXCLUDED.subject, body=EXCLUDED.body, updated_at=EXCLUDED.updated_at`,
+		tpl.ID, tpl.Action, tpl.Subject, tpl.Body, tpl.UpdatedAt,
+	)
+	return err
+}

--- a/internal/domains/portal/repositories/impl/group_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/group_repository_pg.go
@@ -75,7 +75,8 @@ func (r *pgGroupRepo) List(ctx context.Context, f *entities.GroupFilter) ([]*ent
 	if len(clauses) > 0 {
 		where = " WHERE " + strings.Join(clauses, " AND ")
 	}
-	query := base + where + fmt.Sprintf(" ORDER BY created_at DESC LIMIT %d OFFSET %d", f.Limit, f.Offset)
+	query := base + where + fmt.Sprintf(" ORDER BY created_at DESC LIMIT $%d OFFSET $%d", idx, idx+1)
+	args = append(args, f.Limit, f.Offset)
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, 0, err

--- a/internal/domains/portal/repositories/impl/smtp_config_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/smtp_config_repository_pg.go
@@ -3,6 +3,7 @@ package impl
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"system-portal/internal/domains/portal/entities"
 	"system-portal/internal/domains/portal/repositories"
@@ -41,6 +42,13 @@ func (r *pgSMTPConfigRepo) Get(ctx context.Context) (*entities.SMTPConfig, error
 }
 
 func (r *pgSMTPConfigRepo) Create(ctx context.Context, cfg *entities.SMTPConfig) error {
+	var count int
+	if err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM smtp_configs`).Scan(&count); err != nil {
+		return err
+	}
+	if count > 0 {
+		return fmt.Errorf("smtp configuration already exists")
+	}
 	pass := cfg.Password
 	if r.key != "" {
 		if enc, err := utils.EncryptString(cfg.Password, r.key); err == nil {

--- a/internal/domains/portal/repositories/impl/smtp_config_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/smtp_config_repository_pg.go
@@ -1,0 +1,78 @@
+package impl
+
+import (
+	"context"
+	"database/sql"
+
+	"system-portal/internal/domains/portal/entities"
+	"system-portal/internal/domains/portal/repositories"
+	"system-portal/pkg/utils"
+)
+
+type pgSMTPConfigRepo struct {
+	db  *sql.DB
+	key string
+}
+
+func NewSMTPConfigRepositoryPG(db *sql.DB, key string) repositories.SMTPConfigRepository {
+	return &pgSMTPConfigRepo{db: db, key: key}
+}
+
+func (r *pgSMTPConfigRepo) Get(ctx context.Context) (*entities.SMTPConfig, error) {
+	row := r.db.QueryRowContext(ctx, `SELECT id, host, port, username, password, from_addr, tls, created_at, updated_at FROM smtp_configs LIMIT 1`)
+	var cfg entities.SMTPConfig
+	var encPass string
+	if err := row.Scan(&cfg.ID, &cfg.Host, &cfg.Port, &cfg.Username, &encPass, &cfg.From, &cfg.TLS, &cfg.CreatedAt, &cfg.UpdatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if r.key != "" {
+		if plain, err := utils.DecryptString(encPass, r.key); err == nil {
+			cfg.Password = plain
+		} else {
+			cfg.Password = encPass
+		}
+	} else {
+		cfg.Password = encPass
+	}
+	return &cfg, nil
+}
+
+func (r *pgSMTPConfigRepo) Create(ctx context.Context, cfg *entities.SMTPConfig) error {
+	pass := cfg.Password
+	if r.key != "" {
+		if enc, err := utils.EncryptString(cfg.Password, r.key); err == nil {
+			pass = enc
+		} else {
+			return err
+		}
+	}
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO smtp_configs (id, host, port, username, password, from_addr, tls, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$8)`,
+		cfg.ID, cfg.Host, cfg.Port, cfg.Username, pass, cfg.From, cfg.TLS, cfg.CreatedAt,
+	)
+	return err
+}
+
+func (r *pgSMTPConfigRepo) Update(ctx context.Context, cfg *entities.SMTPConfig) error {
+	pass := cfg.Password
+	if r.key != "" {
+		if enc, err := utils.EncryptString(cfg.Password, r.key); err == nil {
+			pass = enc
+		} else {
+			return err
+		}
+	}
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE smtp_configs SET host=$1, port=$2, username=$3, password=$4, from_addr=$5, tls=$6, updated_at=$7 WHERE id=$8`,
+		cfg.Host, cfg.Port, cfg.Username, pass, cfg.From, cfg.TLS, cfg.UpdatedAt, cfg.ID,
+	)
+	return err
+}
+
+func (r *pgSMTPConfigRepo) Delete(ctx context.Context) error {
+	_, err := r.db.ExecContext(ctx, `DELETE FROM smtp_configs`)
+	return err
+}

--- a/internal/domains/portal/repositories/impl/user_repository_pg.go
+++ b/internal/domains/portal/repositories/impl/user_repository_pg.go
@@ -112,7 +112,8 @@ func (r *pgUserRepo) List(ctx context.Context, f *entities.UserFilter) ([]*entit
 	if len(clauses) > 0 {
 		where = " WHERE " + strings.Join(clauses, " AND ")
 	}
-	query := base + where + fmt.Sprintf(" ORDER BY created_at DESC LIMIT %d OFFSET %d", f.Limit, f.Offset)
+	query := base + where + fmt.Sprintf(" ORDER BY created_at DESC LIMIT $%d OFFSET $%d", idx, idx+1)
+	args = append(args, f.Limit, f.Offset)
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, 0, err

--- a/internal/domains/portal/repositories/smtp_config_repository.go
+++ b/internal/domains/portal/repositories/smtp_config_repository.go
@@ -1,0 +1,13 @@
+package repositories
+
+import (
+	"context"
+	"system-portal/internal/domains/portal/entities"
+)
+
+type SMTPConfigRepository interface {
+	Get(ctx context.Context) (*entities.SMTPConfig, error)
+	Create(ctx context.Context, cfg *entities.SMTPConfig) error
+	Update(ctx context.Context, cfg *entities.SMTPConfig) error
+	Delete(ctx context.Context) error
+}

--- a/internal/domains/portal/routes/portal_routes.go
+++ b/internal/domains/portal/routes/portal_routes.go
@@ -130,5 +130,13 @@ func registerConfigRoutes(portal *gin.RouterGroup) {
 		conn.PUT("/ldap", configHandler.UpdateLDAPConfig)
 		conn.DELETE("/ldap", configHandler.DeleteLDAPConfig)
 		conn.POST("/ldap/test", configHandler.TestLDAP)
+
+		conn.GET("/smtp", configHandler.GetSMTPConfig)
+		conn.POST("/smtp", configHandler.CreateSMTPConfig)
+		conn.PUT("/smtp", configHandler.UpdateSMTPConfig)
+		conn.DELETE("/smtp", configHandler.DeleteSMTPConfig)
+
+		conn.GET("/templates/:action", configHandler.GetEmailTemplate)
+		conn.PUT("/templates/:action", configHandler.UpdateEmailTemplate)
 	}
 }

--- a/internal/domains/portal/usecases/config_usecase.go
+++ b/internal/domains/portal/usecases/config_usecase.go
@@ -14,4 +14,11 @@ type ConfigUsecase interface {
 	SetLDAP(ctx context.Context, cfg *entities.LDAPConfig) error
 	DeleteLDAP(ctx context.Context) error
 	TestLDAP(ctx context.Context, cfg *entities.LDAPConfig) error
+
+	GetSMTP(ctx context.Context) (*entities.SMTPConfig, error)
+	SetSMTP(ctx context.Context, cfg *entities.SMTPConfig) error
+	DeleteSMTP(ctx context.Context) error
+
+	GetTemplate(ctx context.Context, action string) (*entities.EmailTemplate, error)
+	SetTemplate(ctx context.Context, tpl *entities.EmailTemplate) error
 }

--- a/internal/services/email/service.go
+++ b/internal/services/email/service.go
@@ -3,7 +3,7 @@ package email
 import (
 	"bytes"
 	"context"
-	"text/template"
+	"html/template"
 
 	portalRepo "system-portal/internal/domains/portal/repositories"
 	"system-portal/internal/shared/config"

--- a/internal/services/email/service.go
+++ b/internal/services/email/service.go
@@ -1,0 +1,59 @@
+package email
+
+import (
+	"bytes"
+	"context"
+	"text/template"
+
+	portalRepo "system-portal/internal/domains/portal/repositories"
+	"system-portal/internal/shared/config"
+	"system-portal/pkg/mailer"
+)
+
+// Service handles sending emails using templates stored in the database
+type Service struct {
+	smtpRepo portalRepo.SMTPConfigRepository
+	tplRepo  portalRepo.EmailTemplateRepository
+}
+
+func NewService(smtpRepo portalRepo.SMTPConfigRepository, tplRepo portalRepo.EmailTemplateRepository) *Service {
+	return &Service{smtpRepo: smtpRepo, tplRepo: tplRepo}
+}
+
+func (s *Service) Send(ctx context.Context, action, to string, data map[string]interface{}) error {
+	if s.smtpRepo == nil || s.tplRepo == nil {
+		return nil
+	}
+	cfg, err := s.smtpRepo.Get(ctx)
+	if err != nil || cfg == nil {
+		return err
+	}
+	tpl, err := s.tplRepo.GetByAction(ctx, action)
+	if err != nil || tpl == nil {
+		return err
+	}
+	subject, err := executeTemplate(tpl.Subject, data)
+	if err != nil {
+		return err
+	}
+	body, err := executeTemplate(tpl.Body, data)
+	if err != nil {
+		return err
+	}
+	m := mailer.NewSMTPMailer(config.SMTPConfig{
+		Host: cfg.Host, Port: cfg.Port, Username: cfg.Username, Password: cfg.Password, From: cfg.From, TLS: cfg.TLS,
+	})
+	return m.Send(to, subject, body)
+}
+
+func executeTemplate(tmpl string, data map[string]interface{}) (string, error) {
+	t, err := template.New("email").Parse(tmpl)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, data); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/internal/shared/config/config.go
+++ b/internal/shared/config/config.go
@@ -81,6 +81,15 @@ type CORSConfig struct {
 	AllowCredentials bool     `mapstructure:"allowCredentials"`
 }
 
+type SMTPConfig struct {
+	Host     string `mapstructure:"host"`
+	Port     int    `mapstructure:"port"`
+	Username string `mapstructure:"username"`
+	Password string `mapstructure:"password"`
+	From     string `mapstructure:"from"`
+	TLS      bool   `mapstructure:"tls"`
+}
+
 func Load() (*Config, error) {
 	var cfg Config
 
@@ -162,4 +171,5 @@ func setDefaults() {
 	viper.SetDefault("security.cors.allowedHeaders", []string{"Authorization", "Content-Type"})
 	viper.SetDefault("security.cors.allowCredentials", true)
 	viper.SetDefault("security.encryptionKey", "")
+
 }

--- a/migrations/004_email_config.sql
+++ b/migrations/004_email_config.sql
@@ -1,0 +1,22 @@
+-- SMTP configuration
+CREATE TABLE IF NOT EXISTS smtp_configs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    host VARCHAR(100) NOT NULL,
+    port INT NOT NULL,
+    username VARCHAR(100),
+    password TEXT NOT NULL,
+    from_addr VARCHAR(100) NOT NULL,
+    tls BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Email templates
+CREATE TABLE IF NOT EXISTS email_templates (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    action VARCHAR(50) UNIQUE NOT NULL,
+    subject TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);

--- a/migrations/005_default_email_templates.sql
+++ b/migrations/005_default_email_templates.sql
@@ -1,0 +1,9 @@
+-- Insert default email templates
+INSERT INTO email_templates (action, subject, body)
+VALUES
+    ('create_user_local', 'OpenVPN account {{.Username}} created', 'Your account {{.Username}} has been created. Password: {{.Password}}'),
+    ('create_user_ldap', 'OpenVPN account {{.Username}} created', 'Your LDAP account {{.Username}} is now active.'),
+    ('enable_user', 'OpenVPN account {{.Username}} enabled', 'Your account {{.Username}} has been enabled.'),
+    ('disable_user', 'OpenVPN account {{.Username}} disabled', 'Your account {{.Username}} has been disabled.'),
+    ('expiration', 'OpenVPN account expiring in {{.Days}} day(s)', 'Your account will expire in {{.Days}} day(s). Please renew.')
+ON CONFLICT (action) DO NOTHING;

--- a/migrations/005_default_email_templates.sql
+++ b/migrations/005_default_email_templates.sql
@@ -5,5 +5,7 @@ VALUES
     ('create_user_ldap', 'OpenVPN account {{.Username}} created', 'Your LDAP account {{.Username}} is now active.'),
     ('enable_user', 'OpenVPN account {{.Username}} enabled', 'Your account {{.Username}} has been enabled.'),
     ('disable_user', 'OpenVPN account {{.Username}} disabled', 'Your account {{.Username}} has been disabled.'),
-    ('expiration', 'OpenVPN account expiring in {{.Days}} day(s)', 'Your account will expire in {{.Days}} day(s). Please renew.')
+    ('expiration', 'OpenVPN account expiring in {{.Days}} day(s)', 'Your account will expire in {{.Days}} day(s). Please renew.'),
+    ('reset_otp', 'OTP reset for {{.Username}}', 'Your one-time password for {{.Username}} has been reset.'),
+    ('change_password', 'Password changed for {{.Username}}', 'Your password for {{.Username}} has been changed.')
 ON CONFLICT (action) DO NOTHING;

--- a/migrations/006_update_create_email_templates.sql
+++ b/migrations/006_update_create_email_templates.sql
@@ -1,0 +1,8 @@
+-- Update create user email templates with detailed information
+UPDATE email_templates
+SET body='Dear {{.Username}},\nAccess control: {{.AccessControl}}\nMAC address: {{.MACAddress}}\nExpiration: {{.Expiration}}\nPassword: {{.Password}}\n\n\u0110\u00E2y l\u00E0 email t\u1EF1 \u0111\u1ED9ng.'
+WHERE action='create_user_local';
+
+UPDATE email_templates
+SET body='Dear {{.Username}},\nAccess control: {{.AccessControl}}\nMAC address: {{.MACAddress}}\nExpiration: {{.Expiration}}\n\n\u0110\u00E2y l\u00E0 email t\u1EF1 \u0111\u1ED9ng.'
+WHERE action='create_user_ldap';

--- a/migrations/006_update_create_email_templates.sql
+++ b/migrations/006_update_create_email_templates.sql
@@ -1,8 +1,8 @@
 -- Update create user email templates with detailed information
 UPDATE email_templates
-SET body='Dear {{.Username}},\nAccess control: {{.AccessControl}}\nMAC address: {{.MACAddress}}\nExpiration: {{.Expiration}}\nPassword: {{.Password}}\n\n\u0110\u00E2y l\u00E0 email t\u1EF1 \u0111\u1ED9ng.'
+SET body=E'Dear {{.Username}},\nAccess control: {{.AccessControl}}\nMAC address: {{.MACAddress}}\nExpiration: {{.Expiration}}\nPassword: {{.Password}}\n\n\u0110\u00E2y l\u00E0 email t\u1EF1 \u0111\u1ED9ng.'
 WHERE action='create_user_local';
 
 UPDATE email_templates
-SET body='Dear {{.Username}},\nAccess control: {{.AccessControl}}\nMAC address: {{.MACAddress}}\nExpiration: {{.Expiration}}\n\n\u0110\u00E2y l\u00E0 email t\u1EF1 \u0111\u1ED9ng.'
+SET body=E'Dear {{.Username}},\nAccess control: {{.AccessControl}}\nMAC address: {{.MACAddress}}\nExpiration: {{.Expiration}}\n\n\u0110\u00E2y l\u00E0 email t\u1EF1 \u0111\u1ED9ng.'
 WHERE action='create_user_ldap';

--- a/migrations/007_email_templates_html.sql
+++ b/migrations/007_email_templates_html.sql
@@ -1,0 +1,28 @@
+-- Use HTML for all email templates
+UPDATE email_templates
+SET body='<p>Dear {{.Username}},</p><p>Access control: {{.AccessControl}}<br>MAC address: {{.MACAddress}}<br>Expiration: {{.Expiration}}<br>Password: {{.Password}}</p><p>Đây là email tự động.</p>'
+WHERE action='create_user_local';
+
+UPDATE email_templates
+SET body='<p>Dear {{.Username}},</p><p>Access control: {{.AccessControl}}<br>MAC address: {{.MACAddress}}<br>Expiration: {{.Expiration}}</p><p>Đây là email tự động.</p>'
+WHERE action='create_user_ldap';
+
+UPDATE email_templates
+SET body='<p>Your account {{.Username}} has been enabled.</p>'
+WHERE action='enable_user';
+
+UPDATE email_templates
+SET body='<p>Your account {{.Username}} has been disabled.</p>'
+WHERE action='disable_user';
+
+UPDATE email_templates
+SET body='<p>Your account will expire in {{.Days}} day(s). Please renew.</p>'
+WHERE action='expiration';
+
+UPDATE email_templates
+SET body='<p>Your one-time password for {{.Username}} has been reset.</p>'
+WHERE action='reset_otp';
+
+UPDATE email_templates
+SET body='<p>Your password for {{.Username}} has been changed.</p>'
+WHERE action='change_password';

--- a/pkg/mailer/mailer.go
+++ b/pkg/mailer/mailer.go
@@ -1,0 +1,65 @@
+package mailer
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/smtp"
+
+	"system-portal/internal/shared/config"
+)
+
+type Mailer interface {
+	Send(to, subject, body string) error
+}
+
+type SMTPMailer struct {
+	cfg config.SMTPConfig
+}
+
+func NewSMTPMailer(cfg config.SMTPConfig) *SMTPMailer {
+	return &SMTPMailer{cfg: cfg}
+}
+
+func (m *SMTPMailer) Send(to, subject, body string) error {
+	if m.cfg.Host == "" || m.cfg.Port == 0 {
+		return fmt.Errorf("smtp not configured")
+	}
+	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.Port)
+	msg := []byte("From: " + m.cfg.From + "\r\n" +
+		"To: " + to + "\r\n" +
+		"Subject: " + subject + "\r\n" +
+		"\r\n" + body + "\r\n")
+
+	auth := smtp.PlainAuth("", m.cfg.Username, m.cfg.Password, m.cfg.Host)
+	if m.cfg.TLS {
+		c, err := smtp.Dial(addr)
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+		if err = c.StartTLS(&tls.Config{ServerName: m.cfg.Host}); err != nil {
+			return err
+		}
+		if err = c.Auth(auth); err != nil {
+			return err
+		}
+		if err = c.Mail(m.cfg.From); err != nil {
+			return err
+		}
+		if err = c.Rcpt(to); err != nil {
+			return err
+		}
+		w, err := c.Data()
+		if err != nil {
+			return err
+		}
+		if _, err = w.Write(msg); err != nil {
+			return err
+		}
+		if err = w.Close(); err != nil {
+			return err
+		}
+		return c.Quit()
+	}
+	return smtp.SendMail(addr, auth, m.cfg.From, []string{to}, msg)
+}

--- a/pkg/mailer/mailer.go
+++ b/pkg/mailer/mailer.go
@@ -28,6 +28,8 @@ func (m *SMTPMailer) Send(to, subject, body string) error {
 	msg := []byte("From: " + m.cfg.From + "\r\n" +
 		"To: " + to + "\r\n" +
 		"Subject: " + subject + "\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: text/html; charset=\"UTF-8\"\r\n" +
 		"\r\n" + body + "\r\n")
 
 	auth := smtp.PlainAuth("", m.cfg.Username, m.cfg.Password, m.cfg.Host)


### PR DESCRIPTION
## Summary
- remove SMTP settings from config file and defaults
- store default email templates via migration
- select template based on auth method when creating users

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_685a72bbfa6483289e3f21f6cf7fd52a